### PR TITLE
adjust discharge dates according to death date

### DIFF
--- a/2018-19/B08 Process SOURCE Care Homes.sps
+++ b/2018-19/B08 Process SOURCE Care Homes.sps
@@ -2,21 +2,28 @@
 get file = !Extracts_Alt + "All Care Home episodes.zsav".
 
 * Adjust discharge dates according to death dates.
+* Match on the death dates from the deceased lookup (year specific).
 match files file = *
     /table = !Extracts_Alt + "All Deaths.zsav"
     /by = chi.
 
+* Create a flag to identify the last record where an episode has been split.
 add files file = *
     /last = last_scem_ep
     /by chi scem.
 
+* Flag to identify which episodes were changed and why.
 Compute changed_dis_date = 0.
 
+* Episodes where the death_date is within 1-5 days of the dis date.
 do if range(datediff(sc_date_2, death_date "days"), 1, 5).
+    * Some tracking variables.
     Compute days_after_death = datediff(sc_date_2, death_date "days").
     Compute changed_dis_date = 1.
+    * Create new variables for now, this will overwrite in the final version.
     Compute new_sc_date_2 = death_date.
     If last_scem_ep new_record_keydate2 = death_date.
+* Episodes not affected by the above but where the CHI death date fits the criteria (most CHIs have the same death date so this is a small number).
 else if range(datediff(sc_date_2, death_date_CHI "days"), 1, 5).
     Compute days_after_death = datediff(sc_date_2, death_date_CHI "days").
     Compute changed_dis_date = 2.
@@ -24,7 +31,7 @@ else if range(datediff(sc_date_2, death_date_CHI "days"), 1, 5).
     If last_scem_ep new_record_keydate2 = death_date_CHI.
 end if.
 
-* Select episodes for given FY.
+* Now select episodes for given FY, need to do this now as discharge dates may have been moved out of the FY above.
 select if Range(record_keydate1, !startFY, !endFY) or (record_keydate1 < !startFY and (record_keydate2 >= !startFY or sysmis(record_keydate2))).
 
 * Match on Client data.

--- a/2018-19/B08 Process SOURCE Care Homes.sps
+++ b/2018-19/B08 Process SOURCE Care Homes.sps
@@ -5,7 +5,7 @@ get file = !Extracts_Alt + "All Care Home episodes.zsav".
 * Match on the death dates from the deceased lookup (year specific).
 match files file = *
     /table = !Extracts_Alt + "All Deaths.zsav"
-    /by = chi.
+    /by chi.
 
 * Create a flag to identify the last record where an episode has been split.
 add files file = *
@@ -16,15 +16,15 @@ add files file = *
 Compute changed_dis_date = 0.
 
 * Episodes where the death_date is within 1-5 days of the dis date.
-do if range(datediff(sc_date_2, death_date "days"), 1, 5).
+do if range(datediff(sc_date_2, death_date, "days"), 1, 5).
     * Some tracking variables.
-    Compute days_after_death = datediff(sc_date_2, death_date "days").
+    Compute days_after_death = datediff(sc_date_2, death_date, "days").
     Compute changed_dis_date = 1.
     * Create new variables for now, this will overwrite in the final version.
     Compute new_sc_date_2 = death_date.
     If last_scem_ep new_record_keydate2 = death_date.
 * Episodes not affected by the above but where the CHI death date fits the criteria (most CHIs have the same death date so this is a small number).
-else if range(datediff(sc_date_2, death_date_CHI "days"), 1, 5).
+else if range(datediff(sc_date_2, death_date_CHI, "days"), 1, 5).
     Compute days_after_death = datediff(sc_date_2, death_date_CHI "days").
     Compute changed_dis_date = 2.
     Compute new_sc_date_2 = death_date_CHI.

--- a/2018-19/B08 Process SOURCE Care Homes.sps
+++ b/2018-19/B08 Process SOURCE Care Homes.sps
@@ -1,5 +1,28 @@
-* Encoding: UTF-8.
+﻿* Encoding: UTF-8.
 get file = !Extracts_Alt + "All Care Home episodes.zsav".
+
+* Adjust discharge dates according to death dates.
+match files file = *
+    /table = !Extracts_Alt + "All Deaths.zsav"
+    /by = chi.
+
+add files file = *
+    /last = last_scem_ep
+    /by chi scem.
+
+Compute changed_dis_date = 0.
+
+do if range(datediff(sc_date_2, death_date "days"), 1, 5).
+    Compute days_after_death = datediff(sc_date_2, death_date "days").
+    Compute changed_dis_date = 1.
+    Compute new_sc_date_2 = death_date.
+    If last_scem_ep new_record_keydate2 = death_date.
+else if range(datediff(sc_date_2, death_date_CHI "days"), 1, 5).
+    Compute days_after_death = datediff(sc_date_2, death_date_CHI "days").
+    Compute changed_dis_date = 2.
+    Compute new_sc_date_2 = death_date_CHI.
+    If last_scem_ep new_record_keydate2 = death_date_CHI.
+end if.
 
 * Select episodes for given FY.
 select if Range(record_keydate1, !startFY, !endFY) or (record_keydate1 < !startFY and (record_keydate2 >= !startFY or sysmis(record_keydate2))).


### PR DESCRIPTION
If the discharge occurs 1 - 5 days after death use the death date in place of the discharge date.
Need to adjust all sc_date_2 (the final discharge date) and only the keydate_2 when this is the last record in the full episode.
Use the `death_date` by preference, which is the NRS death date unless this is missing, in which case it is the CHI death date, otherwise try the CHI death date.
