### PR TITLE
Avoid warnings in test files

### DIFF
--- a/2014-15/B01X Acute_tests.sps
+++ b/2014-15/B01X Acute_tests.sps
@@ -190,7 +190,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2014-15/B02X Maternity_tests.sps
+++ b/2014-15/B02X Maternity_tests.sps
@@ -190,7 +190,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2014-15/B03X Outpatient_tests.sps
+++ b/2014-15/B03X Outpatient_tests.sps
@@ -150,7 +150,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2014-15/B04X MentalHealth_tests.sps
+++ b/2014-15/B04X MentalHealth_tests.sps
@@ -196,7 +196,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2014-15/B06X PIS_tests.sps
+++ b/2014-15/B06X PIS_tests.sps
@@ -86,7 +86,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2014-15/B09X GPOoH_tests.sps
+++ b/2014-15/B09X GPOoH_tests.sps
@@ -142,7 +142,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2014-15/B11X NRS_tests.sps
+++ b/2014-15/B11X NRS_tests.sps
@@ -83,7 +83,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B01X Acute_tests.sps
+++ b/2015-16/B01X Acute_tests.sps
@@ -322,7 +322,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B02X Maternity_tests.sps
+++ b/2015-16/B02X Maternity_tests.sps
@@ -321,7 +321,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B03X Outpatient_tests.sps
+++ b/2015-16/B03X Outpatient_tests.sps
@@ -286,7 +286,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B04X MentalHealth_tests.sps
+++ b/2015-16/B04X MentalHealth_tests.sps
@@ -328,7 +328,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B06X PIS_tests.sps
+++ b/2015-16/B06X PIS_tests.sps
@@ -86,7 +86,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B07X DN_tests.sps
+++ b/2015-16/B07X DN_tests.sps
@@ -212,7 +212,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B08X CH_tests.sps
+++ b/2015-16/B08X CH_tests.sps
@@ -343,7 +343,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B09X GPOoH_tests.sps
+++ b/2015-16/B09X GPOoH_tests.sps
@@ -274,7 +274,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B11X NRS_tests.sps
+++ b/2015-16/B11X NRS_tests.sps
@@ -83,7 +83,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B14X CMH_tests.sps
+++ b/2015-16/B14X CMH_tests.sps
@@ -151,7 +151,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2015-16/B15X Homelessness_tests.sps
+++ b/2015-16/B15X Homelessness_tests.sps
@@ -245,7 +245,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B01X Acute_tests.sps
+++ b/2016-17/B01X Acute_tests.sps
@@ -322,7 +322,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B02X Maternity_tests.sps
+++ b/2016-17/B02X Maternity_tests.sps
@@ -321,7 +321,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B03X Outpatient_tests.sps
+++ b/2016-17/B03X Outpatient_tests.sps
@@ -286,7 +286,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B04X MentalHealth_tests.sps
+++ b/2016-17/B04X MentalHealth_tests.sps
@@ -328,7 +328,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B06X PIS_tests.sps
+++ b/2016-17/B06X PIS_tests.sps
@@ -86,7 +86,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B07X DN_tests.sps
+++ b/2016-17/B07X DN_tests.sps
@@ -212,7 +212,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B08X CH_tests.sps
+++ b/2016-17/B08X CH_tests.sps
@@ -343,7 +343,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B09X GPOoH_tests.sps
+++ b/2016-17/B09X GPOoH_tests.sps
@@ -274,7 +274,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B10X DD_tests.sps
+++ b/2016-17/B10X DD_tests.sps
@@ -59,7 +59,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B11X NRS_tests.sps
+++ b/2016-17/B11X NRS_tests.sps
@@ -83,7 +83,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B14X CMH_tests.sps
+++ b/2016-17/B14X CMH_tests.sps
@@ -151,7 +151,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2016-17/B15X Homelessness_tests.sps
+++ b/2016-17/B15X Homelessness_tests.sps
@@ -245,7 +245,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B01X Acute_tests.sps
+++ b/2017-18/B01X Acute_tests.sps
@@ -322,7 +322,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B02X Maternity_tests.sps
+++ b/2017-18/B02X Maternity_tests.sps
@@ -321,7 +321,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B03X Outpatient_tests.sps
+++ b/2017-18/B03X Outpatient_tests.sps
@@ -286,7 +286,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B04X MentalHealth_tests.sps
+++ b/2017-18/B04X MentalHealth_tests.sps
@@ -328,7 +328,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B06X PIS_tests.sps
+++ b/2017-18/B06X PIS_tests.sps
@@ -86,7 +86,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B07X DN_tests.sps
+++ b/2017-18/B07X DN_tests.sps
@@ -212,7 +212,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B08X Care Homes tests.sps
+++ b/2017-18/B08X Care Homes tests.sps
@@ -440,7 +440,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B09X GPOoH_tests.sps
+++ b/2017-18/B09X GPOoH_tests.sps
@@ -274,7 +274,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B10X DD_tests.sps
+++ b/2017-18/B10X DD_tests.sps
@@ -59,7 +59,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B11X NRS_tests.sps
+++ b/2017-18/B11X NRS_tests.sps
@@ -83,7 +83,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B14X CMH_tests.sps
+++ b/2017-18/B14X CMH_tests.sps
@@ -151,7 +151,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B15X Homelessness_tests.sps
+++ b/2017-18/B15X Homelessness_tests.sps
@@ -245,7 +245,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B16X Home Care tests.sps
+++ b/2017-18/B16X Home Care tests.sps
@@ -370,7 +370,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B17X Alarms Telecare tests.sps
+++ b/2017-18/B17X Alarms Telecare tests.sps
@@ -326,7 +326,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2017-18/B18X SDS tests.sps
+++ b/2017-18/B18X SDS tests.sps
@@ -328,7 +328,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B01X Acute_tests.sps
+++ b/2018-19/B01X Acute_tests.sps
@@ -322,7 +322,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B02X Maternity_tests.sps
+++ b/2018-19/B02X Maternity_tests.sps
@@ -321,7 +321,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B03X Outpatient_tests.sps
+++ b/2018-19/B03X Outpatient_tests.sps
@@ -286,7 +286,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B04X MentalHealth_tests.sps
+++ b/2018-19/B04X MentalHealth_tests.sps
@@ -328,7 +328,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B06X PIS_tests.sps
+++ b/2018-19/B06X PIS_tests.sps
@@ -86,7 +86,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B07X DN_tests.sps
+++ b/2018-19/B07X DN_tests.sps
@@ -212,7 +212,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B09X GPOoH_tests.sps
+++ b/2018-19/B09X GPOoH_tests.sps
@@ -274,7 +274,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B10X DD_tests.sps
+++ b/2018-19/B10X DD_tests.sps
@@ -59,7 +59,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B11X NRS_tests.sps
+++ b/2018-19/B11X NRS_tests.sps
@@ -83,7 +83,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B14X CMH_tests.sps
+++ b/2018-19/B14X CMH_tests.sps
@@ -151,7 +151,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2018-19/B15X Homelessness_tests.sps
+++ b/2018-19/B15X Homelessness_tests.sps
@@ -245,7 +245,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B01X Acute_tests.sps
+++ b/2019-20/B01X Acute_tests.sps
@@ -322,7 +322,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B02X Maternity_tests.sps
+++ b/2019-20/B02X Maternity_tests.sps
@@ -321,7 +321,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B03X Outpatient_tests.sps
+++ b/2019-20/B03X Outpatient_tests.sps
@@ -286,7 +286,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B04X MentalHealth_tests.sps
+++ b/2019-20/B04X MentalHealth_tests.sps
@@ -328,7 +328,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B06X PIS_tests.sps
+++ b/2019-20/B06X PIS_tests.sps
@@ -86,7 +86,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B07X DN_tests.sps
+++ b/2019-20/B07X DN_tests.sps
@@ -212,7 +212,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B09X GPOoH_tests.sps
+++ b/2019-20/B09X GPOoH_tests.sps
@@ -274,7 +274,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B10X DD_tests.sps
+++ b/2019-20/B10X DD_tests.sps
@@ -59,7 +59,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B11X NRS_tests.sps
+++ b/2019-20/B11X NRS_tests.sps
@@ -83,7 +83,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B14X CMH_tests.sps
+++ b/2019-20/B14X CMH_tests.sps
@@ -149,7 +149,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2019-20/B15X Homelessness_tests.sps
+++ b/2019-20/B15X Homelessness_tests.sps
@@ -245,7 +245,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B01X Acute_tests.sps
+++ b/2020-21/B01X Acute_tests.sps
@@ -322,7 +322,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B02X Maternity_tests.sps
+++ b/2020-21/B02X Maternity_tests.sps
@@ -321,7 +321,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B03X Outpatient_tests.sps
+++ b/2020-21/B03X Outpatient_tests.sps
@@ -286,7 +286,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B04X MentalHealth_tests.sps
+++ b/2020-21/B04X MentalHealth_tests.sps
@@ -328,7 +328,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B06X PIS_tests.sps
+++ b/2020-21/B06X PIS_tests.sps
@@ -86,7 +86,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B07X DN_tests.sps
+++ b/2020-21/B07X DN_tests.sps
@@ -212,7 +212,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B09X GPOoH_tests.sps
+++ b/2020-21/B09X GPOoH_tests.sps
@@ -274,7 +274,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B10X DD_tests.sps
+++ b/2020-21/B10X DD_tests.sps
@@ -59,7 +59,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B11X NRS_tests.sps
+++ b/2020-21/B11X NRS_tests.sps
@@ -83,7 +83,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B14X CMH_tests.sps
+++ b/2020-21/B14X CMH_tests.sps
@@ -151,7 +151,9 @@ Dataset close SLFexisting.
 
  * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 

--- a/2020-21/B15X Homelessness_tests.sps
+++ b/2020-21/B15X Homelessness_tests.sps
@@ -245,7 +245,9 @@ Dataset close SLFexisting.
 
 * Produce comparisons.
 Compute Difference = New_Value - Existing_Value.
-Compute PctChange = Difference / Existing_Value * 100.
+Do if Existing_Value NE 0.
+    Compute PctChange = Difference / Existing_Value * 100.
+End if.
 Compute Issue = (abs(PctChange) > 5).
 Alter Type Issue (F1.0) PctChange (PCT4.2).
 


### PR DESCRIPTION
When the `existing_value` was zero / missing the test syntax was generating warnings for a divide by zero, this needlessly complicates the output. This fix just avoids that warning.
