### PR TITLE
Rename IT extracts (SPSS)

### DIFF
--- a/2014-15/A01b Set up 1415 Macros.sps
+++ b/2014-15/A01b Set up 1415 Macros.sps
@@ -24,10 +24,3 @@ Define !FY()
 Define !NextFY ()
     "1516"
 !EndDefine.
-
-*This related to the file in the IT extracts directory and should unzip this in B06 Process PIS extract.
-*Change this to the relevant number specific to FY.
-* Should be '_extract_NUMBER'.
-Define !PIS_extract_number_OLD()
-    "_extract_5_"
-!EndDefine.

--- a/2015-16/A01b Set up 1516 Macros.sps
+++ b/2015-16/A01b Set up 1516 Macros.sps
@@ -15,7 +15,6 @@
 *A01a Set up Universal Macros is located at: 
         * "/conf/irf/11-Development team/Dev00-PLICS-files/All Years/A01a Set up Universal Macros.sps"
 
-
  * Set the Financial Year.
 Define !FY()
    "1516"
@@ -24,11 +23,4 @@ Define !FY()
 * Set the next FY, needed for SPARRA (and HHG).
 Define !NextFY ()
     "1617"
-!EndDefine.
-
-*This related to the file in the IT extracts directory and should unzip this in B06 Process PIS extract.
-*Change this to the relevant number specific to FY.
-* Should be '_extract_NUMBER'.
-Define !PIS_extract_number()
-    "_extract_3_"
 !EndDefine.

--- a/2016-17/A01b Set up 1617 Macros.sps
+++ b/2016-17/A01b Set up 1617 Macros.sps
@@ -24,10 +24,3 @@ Define !FY()
 Define !NextFY ()
     "1718"
 !EndDefine.
-
-*This related to the file in the IT extracts directory and should unzip this in B06 Process PIS extract.
-*Change this to the relevant number specific to FY.
-* Should be '_extract_NUMBER'.
-Define !PIS_extract_number()
-    "_extract_4_"
-!EndDefine.

--- a/2017-18/A01b Set up 1718 Macros.sps
+++ b/2017-18/A01b Set up 1718 Macros.sps
@@ -24,11 +24,3 @@ Define !FY()
 Define !NextFY ()
     "1819"
 !EndDefine.
-
-
-*This related to the file in the IT extracts directory and should unzip this in B06 Process PIS extract.
-*Change this to the relevant number specific to FY.
-* Should be '_extract_NUMBER'.
-Define !PIS_extract_number()
-    "_extract_5_"
-!EndDefine.

--- a/2018-19/A01b Set up 1819 Macros.sps
+++ b/2018-19/A01b Set up 1819 Macros.sps
@@ -24,10 +24,3 @@ Define !FY()
 Define !NextFY ()
     "1920"
 !EndDefine.
-
-*This related to the file in the IT extracts directory and should unzip this in B06 Process PIS extract.
-*Change this to the relevant number specific to FY.
-* Should be '_extract_NUMBER'.
-Define !PIS_extract_number()
-    "_extract_6_"
-!EndDefine.

--- a/2019-20/A01b Set up 1920 Macros.sps
+++ b/2019-20/A01b Set up 1920 Macros.sps
@@ -24,10 +24,3 @@ Define !FY()
 Define !NextFY ()
     "2021"
 !EndDefine.
-
-*This related to the file in the IT extracts directory and should unzip this in B06 Process PIS extract.
-*Change this to the relevant number specific to FY.
-* Should be '_extract_NUMBER'.
-Define !PIS_extract_number()
-    "_extract_7_"
-!EndDefine.

--- a/2020-21/A01b Set up 2021 Macros.sps
+++ b/2020-21/A01b Set up 2021 Macros.sps
@@ -15,7 +15,6 @@
 *A01a Set up Universal Macros is located at: 
         * "/conf/irf/11-Development team/Dev00-PLICS-files/All Years/A01a Set up Universal Macros.sps"
 
-
  * Set the Financial Year.
 Define !FY()
    "2021"
@@ -24,11 +23,4 @@ Define !FY()
 * Set the next FY, needed for SPARRA (and HHG).
 Define !NextFY ()
     "2122"
-!EndDefine.
-
-*This related to the file in the IT extracts directory and should unzip this in B06 Process PIS extract.
-*Change this to the relevant number specific to FY.
-* Should be '_extract_NUMBER'.
-Define !PIS_extract_number()
-    "_extract_8_"
 !EndDefine.

--- a/2021-22/A01b Set up 2122 Macros.sps
+++ b/2021-22/A01b Set up 2122 Macros.sps
@@ -15,7 +15,6 @@
 *A01a Set up Universal Macros is located at: 
         * "/conf/irf/11-Development team/Dev00-PLICS-files/All Years/A01a Set up Universal Macros.sps"
 
-
  * Set the Financial Year.
 Define !FY()
    "2122"
@@ -24,11 +23,4 @@ Define !FY()
 * Set the next FY, needed for SPARRA (and HHG).
 Define !NextFY ()
     "2223"
-!EndDefine.
-
-*This related to the file in the IT extracts directory and should unzip this in B06 Process PIS extract.
-*Change this to the relevant number specific to FY.
-* Should be '_extract_NUMBER'.
-Define !PIS_extract_number()
-    "_extract_9_"
 !EndDefine.

--- a/All_years/01-Macros/Macro-01-Universal.sps
+++ b/All_years/01-Macros/Macro-01-Universal.sps
@@ -160,18 +160,19 @@ Define !IT_Extracts_dir()
 
 * LTC extract.
 Define !LTC_extract_file()
-    !Quote(!Concat(!Unquote(!Eval(!IT_extracts_dir)), !Unquote(!Eval(!IT_extract_ref)), "_extract_1_LTCs.csv"))
+    !Quote(!Concat(!Unquote(!Eval(!IT_extracts_dir)), !Unquote(!Eval(!IT_extract_ref)), "_LTCs.csv"))
 !EndDefine.
 
 * Deaths extract.
 Define !Deaths_extract_file()
-    !Quote(!Concat(!Unquote(!Eval(!IT_extracts_dir)), !Unquote(!Eval(!IT_extract_ref)), "_extract_2_Deaths.csv"))
+    !Quote(!Concat(!Unquote(!Eval(!IT_extracts_dir)), !Unquote(!Eval(!IT_extract_ref)), "_Deaths.csv"))
 !EndDefine.
 
 * PIS extract.
 Define !PIS_extract_file()
-    !Quote(!Concat(!Unquote(!Eval(!IT_extracts_dir)), !Unquote(!Eval(!IT_extract_ref)), !Unquote(!Eval(!PIS_extract_number)), !Unquote(!Eval(!altFY)), ".csv"))
+    !Quote(!Concat(!Unquote(!Eval(!IT_extracts_dir)), !Unquote(!Eval(!IT_extract_ref)), "_PIS_", !Unquote(!Eval(!altFY)), ".csv"))
 !EndDefine.
+
 
 *******************************************************.
 * IT macro for Older years - specific to running 1415.
@@ -183,7 +184,7 @@ Define !IT_extract_ref_OLD()
 
 * PIS extract for OLD years.
 Define !PIS_extract_file_OLD()
-    !Quote(!Concat(!Unquote(!Eval(!IT_extracts_dir)), !Unquote(!Eval(!IT_extract_ref_OLD)), !Unquote(!Eval(!PIS_extract_number_OLD)), !Unquote(!Eval(!altFY)), ".csv"))
+    !Quote(!Concat(!Unquote(!Eval(!IT_extracts_dir)), !Unquote(!Eval(!IT_extract_ref_OLD)), "_PIS_", !Unquote(!Eval(!altFY)), ".csv"))
 !EndDefine.
 
 *******************************************************.


### PR DESCRIPTION
IT extracts now in the format tasknumber_PIS_year or tasknumber_LTC/Deaths. This has been updated in the IT extract folder and also in syntax. This should be in line with the request that new extracts are also renamed. Closes #128 