### PR TITLE
Amend monthly beddays

### DIFF
--- a/R/create_monthly_beddays.R
+++ b/R/create_monthly_beddays.R
@@ -60,12 +60,13 @@ create_monthly_beddays <- function(data, year, admission_date, discharge_date, i
   data <- dplyr::bind_cols(data, beddays) %>%
     dplyr::select(-.data$stay_interval)
 
-  if (include_costs == TRUE) {
+  # Work out costs for each month if applicable
+  if (include_costs) {
     costs <- beddays %>%
-      rename_with(~ str_replace(., "_beddays", "_costs"))
+      dplyr::rename_with(~ str_replace(., "_beddays", "_costs"))
 
-    data <- bind_cols(data, costs) %>%
-      mutate(across(ends_with("_costs"), ~ .x / yearstay * cost_total_net))
+    data <- dplyr::bind_cols(data, costs) %>%
+      dplyr::mutate(dplyr::across(dplyr::ends_with("_costs"), ~ dplyr::if_else(yearstay !=0, .x / yearstay * cost_total_net, 0)))
   }
 
   return(data)

--- a/R/create_monthly_beddays.R
+++ b/R/create_monthly_beddays.R
@@ -66,7 +66,7 @@ create_monthly_beddays <- function(data, year, admission_date, discharge_date, i
       dplyr::rename_with(~ str_replace(., "_beddays", "_costs"))
 
     data <- dplyr::bind_cols(data, costs) %>%
-      dplyr::mutate(dplyr::across(dplyr::ends_with("_costs"), ~ dplyr::if_else(yearstay !=0, .x / yearstay * cost_total_net, 0)))
+      dplyr::mutate(dplyr::across(dplyr::ends_with("_costs"), ~ dplyr::if_else(.x!= 0, .x / yearstay * cost_total_net, 0)))
   }
 
   return(data)

--- a/R/create_monthly_beddays.R
+++ b/R/create_monthly_beddays.R
@@ -5,6 +5,7 @@
 #' @param year The financial year in '1718' format.
 #' @param admission_date The admission/start date variable.
 #' @param discharge_date The admission/start date variable
+#' @param include_costs (default `FALSE`) - Select true for calculating monthly costs
 #' @param count_last (default `TRUE`) - Should the last day be counted,
 #' instead of the first?
 #'
@@ -12,7 +13,7 @@
 #' that count the beddays which occurred in the month.
 #'
 #' @export
-create_monthly_beddays <- function(data, year, admission_date, discharge_date, count_last = TRUE) {
+create_monthly_beddays <- function(data, year, admission_date, discharge_date, include_costs = FALSE, count_last = TRUE)  {
 
   # Create a 'stay interval' from the episode dates
   data <- data %>%
@@ -58,6 +59,14 @@ create_monthly_beddays <- function(data, year, admission_date, discharge_date, c
   # Join the beddays back to the data
   data <- dplyr::bind_cols(data, beddays) %>%
     dplyr::select(-.data$stay_interval)
+
+  if (include_costs == TRUE) {
+    costs <- beddays %>%
+      rename_with(~ str_replace(., "_beddays", "_costs"))
+
+    data <- bind_cols(data, costs) %>%
+      mutate(across(ends_with("_costs"), ~ .x / yearstay * cost_total_net))
+  }
 
   return(data)
 }

--- a/man/create_monthly_beddays.Rd
+++ b/man/create_monthly_beddays.Rd
@@ -10,6 +10,7 @@ create_monthly_beddays(
   year,
   admission_date,
   discharge_date,
+  include_costs = FALSE,
   count_last = TRUE
 )
 }
@@ -21,6 +22,8 @@ create_monthly_beddays(
 \item{admission_date}{The admission/start date variable.}
 
 \item{discharge_date}{The admission/start date variable}
+
+\item{include_costs}{(default \code{FALSE}) - Select true for calculating monthly costs}
 
 \item{count_last}{(default \code{TRUE}) - Should the last day be counted,
 instead of the first?}


### PR DESCRIPTION
Now includes option to `include_costs = TRUE` which will work out costs and assign them to each month. A few tweaks to the original syntax as this was breaking during testing. Specifically against the str_replace for renaming beddays to cost. This code is now working against maternity to calculate monthly beddays and costs. 