### PR TITLE
Change the `cij_marker` type to a numeric

### DIFF
--- a/2014-15/B01 Process Acute (SMR01 and GLS) extract.sps
+++ b/2014-15/B01 Process Acute (SMR01 and GLS) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -64,7 +64,7 @@ GET DATA /TYPE=TXT
       DateofOperation401 A10
       AgeatMidpointofFinancialYear01 F3.0
       ContinuousInpatientStaySMR01incGLS F5.0
-      ContinuousInpatientJourneyMarker01 A5
+      ContinuousInpatientJourneyMarker01 F5.0
       CIJPlannedAdmissionCode01 F1.0
       CIJInpatientDayCaseIdentifierCode01 A2
       CIJTypeofAdmissionCode01 A2
@@ -152,7 +152,7 @@ compute recid = '01B'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
  * Flag GLS records.
@@ -187,9 +187,9 @@ sort cases by uri.
 
 save outfile = !Year_dir + 'acute_temp.zsav'
    /zcompressed.
-  
+
 * Create a file that contains uri, the month number and the net cost and yearstay.
-* Make this look like a 'cross-tab' ready for matching back To the acute_temp file. 
+* Make this look like a 'cross-tab' ready for matching back To the acute_temp file.
 get file = !Year_dir + 'acute_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -222,7 +222,7 @@ aggregate outfile = !Year_dir + 'acute_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 
 match files file = !Year_dir + 'acute_temp.zsav'
@@ -335,7 +335,7 @@ save outfile = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'
     cij_pattype_code
     cij_adm_spec
     cij_dis_spec
-    CIJ_start_date 
+    CIJ_start_date
     CIJ_end_date
     alcohol_adm
     submis_adm

--- a/2014-15/B02 Process Maternity (SMR02) extract.sps
+++ b/2014-15/B02 Process Maternity (SMR02) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
 ********************************************************************************************************.
@@ -11,7 +11,7 @@ GET DATA  /TYPE = TXT
     /QUALIFIER = '"'
     /ARRANGEMENT = DELIMITED
     /FIRSTCASE = 2
-    /VARIABLES = 
+    /VARIABLES =
     CostsFinancialYear A4
     DateofAdmissionFullDate A10
     DateofDischargeFullDate A10
@@ -37,7 +37,7 @@ GET DATA  /TYPE = TXT
     DischargeTransfertoCodenew A2
     DischargedtoLocationCode A5
     ConditionOnDischargeCode F1.0
-    ContinuousInpatientJourneyMarker A5
+    ContinuousInpatientJourneyMarker F5.0
     CIJPlannedAdmissionCode F1.0
     CIJInpatientDayCaseIdentifierCode A2
     CIJTypeofAdmissionCode A2
@@ -159,10 +159,10 @@ for month in (4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3):
 
     # Set up the syntax
     syntax = "!BedDaysPerMonth Month_abbr = " + month_name[month][:3]
-    
+
     # Use the correct admission and discharge variables
     syntax +=  " AdmissionVar = record_keydate1 DischargeVar = record_keydate2."
-    
+
     # print the syntax to the screen
     print(syntax)
 

--- a/2014-15/B04 Process Mental Health (SMR04) extract.sps
+++ b/2014-15/B04 Process Mental Health (SMR04) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -54,7 +54,7 @@ GET DATA  /TYPE=TXT
       AdmissionDiagnosis3Code6char A6
       AdmissionDiagnosis4Code6char A6
       AgeatMidpointofFinancialYear04 F3.0
-      ContinuousInpatientJourneyMarker04 A5
+      ContinuousInpatientJourneyMarker04 F5.0
       CIJPlannedAdmissionCode04 F1.0
       CIJInpatientDayCaseIdentifierCode04 A2
       CIJTypeofAdmissionCode04 A7
@@ -74,7 +74,7 @@ GET DATA  /TYPE=TXT
 CACHE.
 Execute.
 
-* SMR04 specific variables need to be added in here. 
+* SMR04 specific variables need to be added in here.
 rename variables
     AdmissionDiagnosis1Code6char = adcon1
     AdmissionDiagnosis2Code6char = adcon2
@@ -139,7 +139,7 @@ compute ipdc = 'I'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
 if (CIJInpatientDayCaseIdentifierCode04 EQ 'MH') cij_ipdc = 'I'.
@@ -160,11 +160,11 @@ alter type cij_admtype (A2).
 
 sort cases by uri.
 
-* need to add in SMR04 specific variables in to here. 
+* need to add in SMR04 specific variables in to here.
 save outfile = !Year_dir + 'mh_temp.zsav'
    /zcompressed.
-  
-* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file. 
+
+* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file.
 get file = !Year_dir + 'mh_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -197,7 +197,7 @@ aggregate outfile = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 match files file = !Year_dir + 'mh_temp.zsav'
    /table = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'

--- a/2014-15/C01 Make Episode File.sps
+++ b/2014-15/C01 Make Episode File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
@@ -143,8 +143,8 @@ save outfile = !Year_dir + "temp-source-episode-file-Non-CIJ-" + !FY + ".zsav"
 select if any(recid, "01B", "04B", "GLS", "02B").
 
 * Fill in the blank CIJ markers.
-do if (chi ne lag(chi)) AND cij_marker = "" AND chi NE "".
-    compute cij_marker= "1".
+do if (chi ne lag(chi)) AND sysmis(cij_marker) AND chi NE "".
+    compute cij_marker= 1.
 end if.
 
 * Populate ipdc for maternity records.

--- a/2014-15/C07 Calculate pathways cohorts.sps
+++ b/2014-15/C07 Calculate pathways cohorts.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * Cohort Syntax.
 * Andrew Mooney.
 * Feb 2017.
@@ -286,6 +286,9 @@ If any(recid, "AE2", "OoH", "SAS", "N24") AE2_Cost = Cost_Total_Net.
 * Include CMH here?.
 If recid = "DN" Community_Health_Cost = Cost_Total_Net.
 If op1a ne '' Operation_Flag = 1.
+
+* Convert cij_marker to string so we can merge it with recid.
+Alter type cij_marker (A7).
 
 Do if cij_marker NE "".
     Compute cij_Attendance = 1.

--- a/2014-15/D01 Make Individual File.sps
+++ b/2014-15/D01 Make Individual File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * We create a row per chi by producing various summaries from the episode file.
 
 * Produced, based on the original, by James McMahon.
@@ -63,7 +63,7 @@ add files file = *
     /by CHI cij_marker
     /First = Distinct_CIJ.
 
-If cij_marker = "" Distinct_CIJ = 0.
+If sysmis(cij_marker) Distinct_CIJ = 0.
 
 Do if cij_pattype_code = 0.
     Compute CIJ_non_el = Distinct_CIJ.

--- a/2015-16/B01 Process Acute (SMR01 and GLS) extract.sps
+++ b/2015-16/B01 Process Acute (SMR01 and GLS) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -64,7 +64,7 @@ GET DATA /TYPE=TXT
       DateofOperation401 A10
       AgeatMidpointofFinancialYear01 F3.0
       ContinuousInpatientStaySMR01incGLS F5.0
-      ContinuousInpatientJourneyMarker01 A5
+      ContinuousInpatientJourneyMarker01 F5.0
       CIJPlannedAdmissionCode01 F1.0
       CIJInpatientDayCaseIdentifierCode01 A2
       CIJTypeofAdmissionCode01 A2
@@ -152,7 +152,7 @@ compute recid = '01B'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
  * Flag GLS records.
@@ -187,9 +187,9 @@ sort cases by uri.
 
 save outfile = !Year_dir + 'acute_temp.zsav'
    /zcompressed.
-  
+
 * Create a file that contains uri, the month number and the net cost and yearstay.
-* Make this look like a 'cross-tab' ready for matching back To the acute_temp file. 
+* Make this look like a 'cross-tab' ready for matching back To the acute_temp file.
 get file = !Year_dir + 'acute_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -222,7 +222,7 @@ aggregate outfile = !Year_dir + 'acute_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 
 match files file = !Year_dir + 'acute_temp.zsav'
@@ -335,7 +335,7 @@ save outfile = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'
     cij_pattype_code
     cij_adm_spec
     cij_dis_spec
-    CIJ_start_date 
+    CIJ_start_date
     CIJ_end_date
     alcohol_adm
     submis_adm

--- a/2015-16/B02 Process Maternity (SMR02) extract.sps
+++ b/2015-16/B02 Process Maternity (SMR02) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
 ********************************************************************************************************.
@@ -11,7 +11,7 @@ GET DATA  /TYPE = TXT
     /QUALIFIER = '"'
     /ARRANGEMENT = DELIMITED
     /FIRSTCASE = 2
-    /VARIABLES = 
+    /VARIABLES =
     CostsFinancialYear A4
     DateofAdmissionFullDate A10
     DateofDischargeFullDate A10
@@ -37,7 +37,7 @@ GET DATA  /TYPE = TXT
     DischargeTransfertoCodenew A2
     DischargedtoLocationCode A5
     ConditionOnDischargeCode F1.0
-    ContinuousInpatientJourneyMarker A5
+    ContinuousInpatientJourneyMarker F5.0
     CIJPlannedAdmissionCode F1.0
     CIJInpatientDayCaseIdentifierCode A2
     CIJTypeofAdmissionCode A2
@@ -159,10 +159,10 @@ for month in (4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3):
 
     # Set up the syntax
     syntax = "!BedDaysPerMonth Month_abbr = " + month_name[month][:3]
-    
+
     # Use the correct admission and discharge variables
     syntax +=  " AdmissionVar = record_keydate1 DischargeVar = record_keydate2."
-    
+
     # print the syntax to the screen
     print(syntax)
 

--- a/2015-16/B04 Process Mental Health (SMR04) extract.sps
+++ b/2015-16/B04 Process Mental Health (SMR04) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -54,7 +54,7 @@ GET DATA  /TYPE=TXT
       AdmissionDiagnosis3Code6char A6
       AdmissionDiagnosis4Code6char A6
       AgeatMidpointofFinancialYear04 F3.0
-      ContinuousInpatientJourneyMarker04 A5
+      ContinuousInpatientJourneyMarker04 F5.0
       CIJPlannedAdmissionCode04 F1.0
       CIJInpatientDayCaseIdentifierCode04 A2
       CIJTypeofAdmissionCode04 A7
@@ -74,7 +74,7 @@ GET DATA  /TYPE=TXT
 CACHE.
 Execute.
 
-* SMR04 specific variables need to be added in here. 
+* SMR04 specific variables need to be added in here.
 rename variables
     AdmissionDiagnosis1Code6char = adcon1
     AdmissionDiagnosis2Code6char = adcon2
@@ -139,7 +139,7 @@ compute ipdc = 'I'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
 if (CIJInpatientDayCaseIdentifierCode04 EQ 'MH') cij_ipdc = 'I'.
@@ -160,11 +160,11 @@ alter type cij_admtype (A2).
 
 sort cases by uri.
 
-* need to add in SMR04 specific variables in to here. 
+* need to add in SMR04 specific variables in to here.
 save outfile = !Year_dir + 'mh_temp.zsav'
    /zcompressed.
-  
-* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file. 
+
+* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file.
 get file = !Year_dir + 'mh_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -197,7 +197,7 @@ aggregate outfile = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 match files file = !Year_dir + 'mh_temp.zsav'
    /table = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'

--- a/2015-16/C01 Make Episode File.sps
+++ b/2015-16/C01 Make Episode File.sps
@@ -147,8 +147,8 @@ save outfile = !Year_dir + "temp-source-episode-file-Non-CIJ-" + !FY + ".zsav"
 select if any(recid, "01B", "04B", "GLS", "02B").
 
 * Fill in the blank CIJ markers.
-do if (chi ne lag(chi)) AND cij_marker = "" AND chi NE "".
-    compute cij_marker= "1".
+do if (chi ne lag(chi)) AND sysmis(cij_marker) AND chi NE "".
+    compute cij_marker= 1.
 end if.
 
 * Populate ipdc for maternity records.
@@ -415,6 +415,7 @@ save outfile = !Year_dir + "temp-source-episode-file-3-" + !FY + ".zsav"
     /Drop Valid_CHI PPA
     /zcompressed.
 get file = !Year_dir + "temp-source-episode-file-3-" + !FY + ".zsav".
+
 
 * Housekeeping.
 Erase file = !Year_dir + "temp-source-episode-file-Non-CIJ-" + !FY + ".zsav".

--- a/2015-16/C07 Calculate pathways cohorts.sps
+++ b/2015-16/C07 Calculate pathways cohorts.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * Cohort Syntax.
 * Andrew Mooney.
 * Feb 2017.
@@ -286,6 +286,9 @@ If any(recid, "AE2", "OoH", "SAS", "N24") AE2_Cost = Cost_Total_Net.
 * Include CMH here?.
 If recid = "DN" Community_Health_Cost = Cost_Total_Net.
 If op1a ne '' Operation_Flag = 1.
+
+* Convert cij_marker to string so we can merge it with recid.
+Alter type cij_marker (A7).
 
 Do if cij_marker NE "".
     Compute cij_Attendance = 1.

--- a/2015-16/D01 Make Individual File.sps
+++ b/2015-16/D01 Make Individual File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * We create a row per chi by producing various summaries from the episode file.
 
 * Produced, based on the original, by James McMahon.
@@ -63,7 +63,7 @@ add files file = *
     /by CHI cij_marker
     /First = Distinct_CIJ.
 
-If cij_marker = "" Distinct_CIJ = 0.
+If sysmis(cij_marker) Distinct_CIJ = 0.
 
 Do if cij_pattype_code = 0.
     Compute CIJ_non_el = Distinct_CIJ.

--- a/2016-17/B01 Process Acute (SMR01 and GLS) extract.sps
+++ b/2016-17/B01 Process Acute (SMR01 and GLS) extract.sps
@@ -64,7 +64,7 @@ GET DATA /TYPE=TXT
       DateofOperation401 A10
       AgeatMidpointofFinancialYear01 F3.0
       ContinuousInpatientStaySMR01incGLS F5.0
-      ContinuousInpatientJourneyMarker01 A5
+      ContinuousInpatientJourneyMarker01 F5.0
       CIJPlannedAdmissionCode01 F1.0
       CIJInpatientDayCaseIdentifierCode01 A2
       CIJTypeofAdmissionCode01 A2

--- a/2016-17/B02 Process Maternity (SMR02) extract.sps
+++ b/2016-17/B02 Process Maternity (SMR02) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
 ********************************************************************************************************.
@@ -11,7 +11,7 @@ GET DATA  /TYPE = TXT
     /QUALIFIER = '"'
     /ARRANGEMENT = DELIMITED
     /FIRSTCASE = 2
-    /VARIABLES = 
+    /VARIABLES =
     CostsFinancialYear A4
     DateofAdmissionFullDate A10
     DateofDischargeFullDate A10
@@ -37,7 +37,7 @@ GET DATA  /TYPE = TXT
     DischargeTransfertoCodenew A2
     DischargedtoLocationCode A5
     ConditionOnDischargeCode F1.0
-    ContinuousInpatientJourneyMarker A5
+    ContinuousInpatientJourneyMarker F5.0
     CIJPlannedAdmissionCode F1.0
     CIJInpatientDayCaseIdentifierCode A2
     CIJTypeofAdmissionCode A2
@@ -159,10 +159,10 @@ for month in (4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3):
 
     # Set up the syntax
     syntax = "!BedDaysPerMonth Month_abbr = " + month_name[month][:3]
-    
+
     # Use the correct admission and discharge variables
     syntax +=  " AdmissionVar = record_keydate1 DischargeVar = record_keydate2."
-    
+
     # print the syntax to the screen
     print(syntax)
 

--- a/2016-17/B04 Process Mental Health (SMR04) extract.sps
+++ b/2016-17/B04 Process Mental Health (SMR04) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -54,7 +54,7 @@ GET DATA  /TYPE=TXT
       AdmissionDiagnosis3Code6char A6
       AdmissionDiagnosis4Code6char A6
       AgeatMidpointofFinancialYear04 F3.0
-      ContinuousInpatientJourneyMarker04 A5
+      ContinuousInpatientJourneyMarker04 F5.0
       CIJPlannedAdmissionCode04 F1.0
       CIJInpatientDayCaseIdentifierCode04 A2
       CIJTypeofAdmissionCode04 A7
@@ -74,7 +74,7 @@ GET DATA  /TYPE=TXT
 CACHE.
 Execute.
 
-* SMR04 specific variables need to be added in here. 
+* SMR04 specific variables need to be added in here.
 rename variables
     AdmissionDiagnosis1Code6char = adcon1
     AdmissionDiagnosis2Code6char = adcon2
@@ -139,7 +139,7 @@ compute ipdc = 'I'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
 if (CIJInpatientDayCaseIdentifierCode04 EQ 'MH') cij_ipdc = 'I'.
@@ -160,11 +160,11 @@ alter type cij_admtype (A2).
 
 sort cases by uri.
 
-* need to add in SMR04 specific variables in to here. 
+* need to add in SMR04 specific variables in to here.
 save outfile = !Year_dir + 'mh_temp.zsav'
    /zcompressed.
-  
-* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file. 
+
+* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file.
 get file = !Year_dir + 'mh_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -197,7 +197,7 @@ aggregate outfile = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 match files file = !Year_dir + 'mh_temp.zsav'
    /table = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'

--- a/2016-17/C01 Make Episode File.sps
+++ b/2016-17/C01 Make Episode File.sps
@@ -150,8 +150,8 @@ save outfile = !Year_dir + "temp-source-episode-file-Non-CIJ-" + !FY + ".zsav"
 select if any(recid, "01B", "04B", "GLS", "02B").
 
 * Fill in the blank CIJ markers.
-do if (chi ne lag(chi)) AND cij_marker = "" AND chi NE "".
-    compute cij_marker= "1".
+do if (chi ne lag(chi)) AND sysmis(cij_marker) AND chi NE "".
+    compute cij_marker= 1.
 end if.
 
 * Populate ipdc for maternity records.

--- a/2016-17/C02 Link Delayed Discharge episodes.sps
+++ b/2016-17/C02 Link Delayed Discharge episodes.sps
@@ -312,7 +312,7 @@ add files
     /File =  !Year_dir + "DD_for_source-20" + !FY + ".zsav"
     /by chi keydate1_dateformat.
 
-Do if chi NE "" and cij_marker NE "".
+Do if chi NE "" and cij_marker NE sysmis(cij_marker).
     Compute has_delay = SMRType = "DD-CIJ".
 End if.
 

--- a/2016-17/C02 Link Delayed Discharge episodes.sps
+++ b/2016-17/C02 Link Delayed Discharge episodes.sps
@@ -16,11 +16,8 @@ save outfile =  !Year_dir + "slf_reduced_for_DD.zsav"
 get file =  !Year_dir + "slf_reduced_for_DD.zsav".
 
 * Create a copy of the CIJ marker.
-String temp_cij_marker (A5).
+Numeric temp_cij_marker (F5.0).
 Compute temp_cij_marker = cij_marker.
-
-* Set blank to be user missing (important for later).
-Missing Values temp_cij_marker ("     ").
 
 * Add all files together.
 add files
@@ -56,7 +53,7 @@ Do if chi = lag(chi) and recid = "DD" and lag(recid) = "04B" and sysmiss(keydate
 End if.
 
 * Use Min and Max CIJ dates to fill in temp_cij_marker - where possible - DD episodes with no CIJ.
-Do if chi = lag(chi) and missing(temp_cij_marker).
+Do if chi = lag(chi) and sysmis(temp_cij_marker).
     * Create flags simply to check rows where CIJ markers are being added.
     * don't expect any of these.
     compute Flag_1 = 0.
@@ -107,7 +104,7 @@ End if.
 * Sort in the opposite direction.
 sort cases by chi (A) keydate1_dateformat (D) order (A).
 * If DD record date ends within CIJ dates but starts before.
-Do if recid = 'DD' and chi = lag(chi) and missing(temp_cij_marker).
+Do if recid = 'DD' and chi = lag(chi) and sysmis(temp_cij_marker).
     Compute Flag_4 = 0.
     Do if keydate1_dateformat LE lag(CIJ_start_date) and Range(keydate2_dateformat, lag(CIJ_start_date) - time.days(1), lag(CIJ_end_date) + time.days(1)).
         Compute Flag_4 = 1.
@@ -173,7 +170,7 @@ Variable labels
     no_cij "no-CIJ attached".
 
 * Flag DDs which don't seem to have an associated hospital stay.
-if missing(temp_cij_marker) and recid = "DD" no_cij = 1.
+if sysmis(temp_cij_marker) and recid = "DD" no_cij = 1.
 
 save outfile = !Year_dir + "DD_Temp-2.zsav"
     /zcompressed.

--- a/2016-17/C07 Calculate pathways cohorts.sps
+++ b/2016-17/C07 Calculate pathways cohorts.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * Cohort Syntax.
 * Andrew Mooney.
 * Feb 2017.
@@ -286,6 +286,9 @@ If any(recid, "AE2", "OoH", "SAS", "N24") AE2_Cost = Cost_Total_Net.
 * Include CMH here?.
 If recid = "DN" Community_Health_Cost = Cost_Total_Net.
 If op1a ne '' Operation_Flag = 1.
+
+* Convert cij_marker to string so we can merge it with recid.
+Alter type cij_marker (A7).
 
 Do if cij_marker NE "".
     Compute cij_Attendance = 1.

--- a/2016-17/D01 Make Individual File.sps
+++ b/2016-17/D01 Make Individual File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * We create a row per chi by producing various summaries from the episode file.
 
 * Produced, based on the original, by James McMahon.
@@ -63,7 +63,7 @@ add files file = *
     /by CHI cij_marker
     /First = Distinct_CIJ.
 
-If cij_marker = "" Distinct_CIJ = 0.
+If sysmis(cij_marker) Distinct_CIJ = 0.
 
 Do if cij_pattype_code = 0.
     Compute CIJ_non_el = Distinct_CIJ.

--- a/2017-18/B01 Process Acute (SMR01 and GLS) extract.sps
+++ b/2017-18/B01 Process Acute (SMR01 and GLS) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -64,7 +64,7 @@ GET DATA /TYPE=TXT
       DateofOperation401 A10
       AgeatMidpointofFinancialYear01 F3.0
       ContinuousInpatientStaySMR01incGLS F5.0
-      ContinuousInpatientJourneyMarker01 A5
+      ContinuousInpatientJourneyMarker01 F5.0
       CIJPlannedAdmissionCode01 F1.0
       CIJInpatientDayCaseIdentifierCode01 A2
       CIJTypeofAdmissionCode01 A2
@@ -152,7 +152,7 @@ compute recid = '01B'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
  * Flag GLS records.
@@ -187,9 +187,9 @@ sort cases by uri.
 
 save outfile = !Year_dir + 'acute_temp.zsav'
    /zcompressed.
-  
+
 * Create a file that contains uri, the month number and the net cost and yearstay.
-* Make this look like a 'cross-tab' ready for matching back To the acute_temp file. 
+* Make this look like a 'cross-tab' ready for matching back To the acute_temp file.
 get file = !Year_dir + 'acute_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -222,7 +222,7 @@ aggregate outfile = !Year_dir + 'acute_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 
 match files file = !Year_dir + 'acute_temp.zsav'
@@ -335,7 +335,7 @@ save outfile = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'
     cij_pattype_code
     cij_adm_spec
     cij_dis_spec
-    CIJ_start_date 
+    CIJ_start_date
     CIJ_end_date
     alcohol_adm
     submis_adm

--- a/2017-18/B02 Process Maternity (SMR02) extract.sps
+++ b/2017-18/B02 Process Maternity (SMR02) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
 ********************************************************************************************************.
@@ -11,7 +11,7 @@ GET DATA  /TYPE = TXT
     /QUALIFIER = '"'
     /ARRANGEMENT = DELIMITED
     /FIRSTCASE = 2
-    /VARIABLES = 
+    /VARIABLES =
     CostsFinancialYear A4
     DateofAdmissionFullDate A10
     DateofDischargeFullDate A10
@@ -37,7 +37,7 @@ GET DATA  /TYPE = TXT
     DischargeTransfertoCodenew A2
     DischargedtoLocationCode A5
     ConditionOnDischargeCode F1.0
-    ContinuousInpatientJourneyMarker A5
+    ContinuousInpatientJourneyMarker F5.0
     CIJPlannedAdmissionCode F1.0
     CIJInpatientDayCaseIdentifierCode A2
     CIJTypeofAdmissionCode A2
@@ -159,10 +159,10 @@ for month in (4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3):
 
     # Set up the syntax
     syntax = "!BedDaysPerMonth Month_abbr = " + month_name[month][:3]
-    
+
     # Use the correct admission and discharge variables
     syntax +=  " AdmissionVar = record_keydate1 DischargeVar = record_keydate2."
-    
+
     # print the syntax to the screen
     print(syntax)
 

--- a/2017-18/B04 Process Mental Health (SMR04) extract.sps
+++ b/2017-18/B04 Process Mental Health (SMR04) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -54,7 +54,7 @@ GET DATA  /TYPE=TXT
       AdmissionDiagnosis3Code6char A6
       AdmissionDiagnosis4Code6char A6
       AgeatMidpointofFinancialYear04 F3.0
-      ContinuousInpatientJourneyMarker04 A5
+      ContinuousInpatientJourneyMarker04 F5.0
       CIJPlannedAdmissionCode04 F1.0
       CIJInpatientDayCaseIdentifierCode04 A2
       CIJTypeofAdmissionCode04 A7
@@ -74,7 +74,7 @@ GET DATA  /TYPE=TXT
 CACHE.
 Execute.
 
-* SMR04 specific variables need to be added in here. 
+* SMR04 specific variables need to be added in here.
 rename variables
     AdmissionDiagnosis1Code6char = adcon1
     AdmissionDiagnosis2Code6char = adcon2
@@ -139,7 +139,7 @@ compute ipdc = 'I'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
 if (CIJInpatientDayCaseIdentifierCode04 EQ 'MH') cij_ipdc = 'I'.
@@ -160,11 +160,11 @@ alter type cij_admtype (A2).
 
 sort cases by uri.
 
-* need to add in SMR04 specific variables in to here. 
+* need to add in SMR04 specific variables in to here.
 save outfile = !Year_dir + 'mh_temp.zsav'
    /zcompressed.
-  
-* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file. 
+
+* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file.
 get file = !Year_dir + 'mh_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -197,7 +197,7 @@ aggregate outfile = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 match files file = !Year_dir + 'mh_temp.zsav'
    /table = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'

--- a/2017-18/C01 Make Episode File.sps
+++ b/2017-18/C01 Make Episode File.sps
@@ -158,8 +158,8 @@ save outfile = !Year_dir + "temp-source-episode-file-Non-CIJ-" + !FY + ".zsav"
 select if any(recid, "01B", "04B", "GLS", "02B").
 
 * Fill in the blank CIJ markers.
-do if (chi ne lag(chi)) AND cij_marker = "" AND chi NE "".
-    compute cij_marker= "1".
+do if (chi ne lag(chi)) AND sysmis(cij_marker) AND chi NE "".
+    compute cij_marker= 1.
 end if.
 
 * Populate ipdc for maternity records.
@@ -217,7 +217,7 @@ Do if any (recid, "01B", "02B", "04B", "GLS").
         Do if cij_pattype = "Non-Elective".
             * Initialise PPA flag for relevant records.
             Compute PPA = 0.
-            
+
             *Set op exclusions for selection below.
             *Hyper / CHF main ops.
             Do if range (char.Substr(op1a, 1 , 3), "K01", "K50") or

--- a/2017-18/C02 Link Delayed Discharge episodes.sps
+++ b/2017-18/C02 Link Delayed Discharge episodes.sps
@@ -312,7 +312,7 @@ add files
     /File =  !Year_dir + "DD_for_source-20" + !FY + ".zsav"
     /by chi keydate1_dateformat.
 
-Do if chi NE "" and cij_marker NE "".
+Do if chi NE "" and cij_marker NE sysmis(cij_marker).
     Compute has_delay = SMRType = "DD-CIJ".
 End if.
 

--- a/2017-18/C02 Link Delayed Discharge episodes.sps
+++ b/2017-18/C02 Link Delayed Discharge episodes.sps
@@ -16,11 +16,8 @@ save outfile =  !Year_dir + "slf_reduced_for_DD.zsav"
 get file =  !Year_dir + "slf_reduced_for_DD.zsav".
 
 * Create a copy of the CIJ marker.
-String temp_cij_marker (A5).
+Numeric temp_cij_marker (F5.0).
 Compute temp_cij_marker = cij_marker.
-
-* Set blank to be user missing (important for later).
-Missing Values temp_cij_marker ("     ").
 
 * Add all files together.
 add files
@@ -56,7 +53,7 @@ Do if chi = lag(chi) and recid = "DD" and lag(recid) = "04B" and sysmiss(keydate
 End if.
 
 * Use Min and Max CIJ dates to fill in temp_cij_marker - where possible - DD episodes with no CIJ.
-Do if chi = lag(chi) and missing(temp_cij_marker).
+Do if chi = lag(chi) and sysmis(temp_cij_marker).
     * Create flags simply to check rows where CIJ markers are being added.
     * don't expect any of these.
     compute Flag_1 = 0.
@@ -107,7 +104,7 @@ End if.
 * Sort in the opposite direction.
 sort cases by chi (A) keydate1_dateformat (D) order (A).
 * If DD record date ends within CIJ dates but starts before.
-Do if recid = 'DD' and chi = lag(chi) and missing(temp_cij_marker).
+Do if recid = 'DD' and chi = lag(chi) and sysmis(temp_cij_marker).
     Compute Flag_4 = 0.
     Do if keydate1_dateformat LE lag(CIJ_start_date) and Range(keydate2_dateformat, lag(CIJ_start_date) - time.days(1), lag(CIJ_end_date) + time.days(1)).
         Compute Flag_4 = 1.
@@ -173,7 +170,7 @@ Variable labels
     no_cij "no-CIJ attached".
 
 * Flag DDs which don't seem to have an associated hospital stay.
-if missing(temp_cij_marker) and recid = "DD" no_cij = 1.
+if sysmis(temp_cij_marker) and recid = "DD" no_cij = 1.
 
 save outfile = !Year_dir + "DD_Temp-2.zsav"
     /zcompressed.

--- a/2017-18/C03 Link Homelessness.sps
+++ b/2017-18/C03 Link Homelessness.sps
@@ -26,7 +26,7 @@ aggregate
     /max_records = max(num_records).
 
  * Assuming it must be <=9.
-Alter Type max_records (F1.0).
+Alter Type max_records (AMIN).
 
  * Ugly hack because SPSS...
  * Take the max_records number and generate two macros using this.

--- a/2017-18/C07 Calculate pathways cohorts.sps
+++ b/2017-18/C07 Calculate pathways cohorts.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * Cohort Syntax.
 * Andrew Mooney.
 * Feb 2017.
@@ -286,6 +286,9 @@ If any(recid, "AE2", "OoH", "SAS", "N24") AE2_Cost = Cost_Total_Net.
 * Include CMH here?.
 If recid = "DN" Community_Health_Cost = Cost_Total_Net.
 If op1a ne '' Operation_Flag = 1.
+
+* Convert cij_marker to string so we can merge it with recid.
+Alter type cij_marker (A7).
 
 Do if cij_marker NE "".
     Compute cij_Attendance = 1.

--- a/2017-18/D01 Make Individual File.sps
+++ b/2017-18/D01 Make Individual File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * We create a row per chi by producing various summaries from the episode file.
 
 * Produced, based on the original, by James McMahon.
@@ -63,7 +63,7 @@ add files file = *
     /by CHI cij_marker
     /First = Distinct_CIJ.
 
-If cij_marker = "" Distinct_CIJ = 0.
+If sysmis(cij_marker) Distinct_CIJ = 0.
 
 Do if cij_pattype_code = 0.
     Compute CIJ_non_el = Distinct_CIJ.

--- a/2018-19/B01 Process Acute (SMR01 and GLS) extract.sps
+++ b/2018-19/B01 Process Acute (SMR01 and GLS) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -64,7 +64,7 @@ GET DATA /TYPE=TXT
       DateofOperation401 A10
       AgeatMidpointofFinancialYear01 F3.0
       ContinuousInpatientStaySMR01incGLS F5.0
-      ContinuousInpatientJourneyMarker01 A5
+      ContinuousInpatientJourneyMarker01 F5.0
       CIJPlannedAdmissionCode01 F1.0
       CIJInpatientDayCaseIdentifierCode01 A2
       CIJTypeofAdmissionCode01 A2
@@ -152,7 +152,7 @@ compute recid = '01B'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
  * Flag GLS records.
@@ -187,9 +187,9 @@ sort cases by uri.
 
 save outfile = !Year_dir + 'acute_temp.zsav'
    /zcompressed.
-  
+
 * Create a file that contains uri, the month number and the net cost and yearstay.
-* Make this look like a 'cross-tab' ready for matching back To the acute_temp file. 
+* Make this look like a 'cross-tab' ready for matching back To the acute_temp file.
 get file = !Year_dir + 'acute_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -222,7 +222,7 @@ aggregate outfile = !Year_dir + 'acute_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 
 match files file = !Year_dir + 'acute_temp.zsav'
@@ -335,7 +335,7 @@ save outfile = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'
     cij_pattype_code
     cij_adm_spec
     cij_dis_spec
-    CIJ_start_date 
+    CIJ_start_date
     CIJ_end_date
     alcohol_adm
     submis_adm

--- a/2018-19/B02 Process Maternity (SMR02) extract.sps
+++ b/2018-19/B02 Process Maternity (SMR02) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
 ********************************************************************************************************.
@@ -11,7 +11,7 @@ GET DATA  /TYPE = TXT
     /QUALIFIER = '"'
     /ARRANGEMENT = DELIMITED
     /FIRSTCASE = 2
-    /VARIABLES = 
+    /VARIABLES =
     CostsFinancialYear A4
     DateofAdmissionFullDate A10
     DateofDischargeFullDate A10
@@ -37,7 +37,7 @@ GET DATA  /TYPE = TXT
     DischargeTransfertoCodenew A2
     DischargedtoLocationCode A5
     ConditionOnDischargeCode F1.0
-    ContinuousInpatientJourneyMarker A5
+    ContinuousInpatientJourneyMarker F5.0
     CIJPlannedAdmissionCode F1.0
     CIJInpatientDayCaseIdentifierCode A2
     CIJTypeofAdmissionCode A2
@@ -159,10 +159,10 @@ for month in (4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3):
 
     # Set up the syntax
     syntax = "!BedDaysPerMonth Month_abbr = " + month_name[month][:3]
-    
+
     # Use the correct admission and discharge variables
     syntax +=  " AdmissionVar = record_keydate1 DischargeVar = record_keydate2."
-    
+
     # print the syntax to the screen
     print(syntax)
 

--- a/2018-19/B04 Process Mental Health (SMR04) extract.sps
+++ b/2018-19/B04 Process Mental Health (SMR04) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -54,7 +54,7 @@ GET DATA  /TYPE=TXT
       AdmissionDiagnosis3Code6char A6
       AdmissionDiagnosis4Code6char A6
       AgeatMidpointofFinancialYear04 F3.0
-      ContinuousInpatientJourneyMarker04 A5
+      ContinuousInpatientJourneyMarker04 F5.0
       CIJPlannedAdmissionCode04 F1.0
       CIJInpatientDayCaseIdentifierCode04 A2
       CIJTypeofAdmissionCode04 A7
@@ -74,7 +74,7 @@ GET DATA  /TYPE=TXT
 CACHE.
 Execute.
 
-* SMR04 specific variables need to be added in here. 
+* SMR04 specific variables need to be added in here.
 rename variables
     AdmissionDiagnosis1Code6char = adcon1
     AdmissionDiagnosis2Code6char = adcon2
@@ -139,7 +139,7 @@ compute ipdc = 'I'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
 if (CIJInpatientDayCaseIdentifierCode04 EQ 'MH') cij_ipdc = 'I'.
@@ -160,11 +160,11 @@ alter type cij_admtype (A2).
 
 sort cases by uri.
 
-* need to add in SMR04 specific variables in to here. 
+* need to add in SMR04 specific variables in to here.
 save outfile = !Year_dir + 'mh_temp.zsav'
    /zcompressed.
-  
-* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file. 
+
+* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file.
 get file = !Year_dir + 'mh_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -197,7 +197,7 @@ aggregate outfile = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 match files file = !Year_dir + 'mh_temp.zsav'
    /table = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'

--- a/2018-19/C01 Make Episode File.sps
+++ b/2018-19/C01 Make Episode File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
@@ -151,8 +151,8 @@ save outfile = !Year_dir + "temp-source-episode-file-Non-CIJ-" + !FY + ".zsav"
 select if any(recid, "01B", "04B", "GLS", "02B").
 
 * Fill in the blank CIJ markers.
-do if (chi ne lag(chi)) AND cij_marker = "" AND chi NE "".
-    compute cij_marker= "1".
+do if (chi ne lag(chi)) AND sysmis(cij_marker) AND chi NE "".
+    compute cij_marker= 1.
 end if.
 
 * Populate ipdc for maternity records.

--- a/2018-19/C02 Link Delayed Discharge episodes.sps
+++ b/2018-19/C02 Link Delayed Discharge episodes.sps
@@ -312,7 +312,7 @@ add files
     /File =  !Year_dir + "DD_for_source-20" + !FY + ".zsav"
     /by chi keydate1_dateformat.
 
-Do if chi NE "" and cij_marker NE "".
+Do if chi NE "" and cij_marker NE sysmis(cij_marker).
     Compute has_delay = SMRType = "DD-CIJ".
 End if.
 

--- a/2018-19/C02 Link Delayed Discharge episodes.sps
+++ b/2018-19/C02 Link Delayed Discharge episodes.sps
@@ -16,11 +16,8 @@ save outfile =  !Year_dir + "slf_reduced_for_DD.zsav"
 get file =  !Year_dir + "slf_reduced_for_DD.zsav".
 
 * Create a copy of the CIJ marker.
-String temp_cij_marker (A5).
+Numeric temp_cij_marker (F5.0).
 Compute temp_cij_marker = cij_marker.
-
-* Set blank to be user missing (important for later).
-Missing Values temp_cij_marker ("     ").
 
 * Add all files together.
 add files
@@ -56,7 +53,7 @@ Do if chi = lag(chi) and recid = "DD" and lag(recid) = "04B" and sysmiss(keydate
 End if.
 
 * Use Min and Max CIJ dates to fill in temp_cij_marker - where possible - DD episodes with no CIJ.
-Do if chi = lag(chi) and missing(temp_cij_marker).
+Do if chi = lag(chi) and sysmis(temp_cij_marker).
     * Create flags simply to check rows where CIJ markers are being added.
     * don't expect any of these.
     compute Flag_1 = 0.
@@ -107,7 +104,7 @@ End if.
 * Sort in the opposite direction.
 sort cases by chi (A) keydate1_dateformat (D) order (A).
 * If DD record date ends within CIJ dates but starts before.
-Do if recid = 'DD' and chi = lag(chi) and missing(temp_cij_marker).
+Do if recid = 'DD' and chi = lag(chi) and sysmis(temp_cij_marker).
     Compute Flag_4 = 0.
     Do if keydate1_dateformat LE lag(CIJ_start_date) and Range(keydate2_dateformat, lag(CIJ_start_date) - time.days(1), lag(CIJ_end_date) + time.days(1)).
         Compute Flag_4 = 1.
@@ -173,7 +170,7 @@ Variable labels
     no_cij "no-CIJ attached".
 
 * Flag DDs which don't seem to have an associated hospital stay.
-if missing(temp_cij_marker) and recid = "DD" no_cij = 1.
+if sysmis(temp_cij_marker) and recid = "DD" no_cij = 1.
 
 save outfile = !Year_dir + "DD_Temp-2.zsav"
     /zcompressed.

--- a/2018-19/C03 Link Homelessness.sps
+++ b/2018-19/C03 Link Homelessness.sps
@@ -26,7 +26,7 @@ aggregate
     /max_records = max(num_records).
 
  * Assuming it must be <=9.
-Alter Type max_records (F1.0).
+Alter Type max_records (AMIN).
 
  * Ugly hack because SPSS...
  * Take the max_records number and generate two macros using this.

--- a/2018-19/C07 Calculate pathways cohorts.sps
+++ b/2018-19/C07 Calculate pathways cohorts.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * Cohort Syntax.
 * Andrew Mooney.
 * Feb 2017.
@@ -286,6 +286,9 @@ If any(recid, "AE2", "OoH", "SAS", "N24") AE2_Cost = Cost_Total_Net.
 * Include CMH here?.
 If recid = "DN" Community_Health_Cost = Cost_Total_Net.
 If op1a ne '' Operation_Flag = 1.
+
+* Convert cij_marker to string so we can merge it with recid.
+Alter type cij_marker (A7).
 
 Do if cij_marker NE "".
     Compute cij_Attendance = 1.

--- a/2018-19/D01 Make Individual File.sps
+++ b/2018-19/D01 Make Individual File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * We create a row per chi by producing various summaries from the episode file.
 
 * Produced, based on the original, by James McMahon.
@@ -63,7 +63,7 @@ add files file = *
     /by CHI cij_marker
     /First = Distinct_CIJ.
 
-If cij_marker = "" Distinct_CIJ = 0.
+If sysmis(cij_marker) Distinct_CIJ = 0.
 
 Do if cij_pattype_code = 0.
     Compute CIJ_non_el = Distinct_CIJ.

--- a/2019-20/B01 Process Acute (SMR01 and GLS) extract.sps
+++ b/2019-20/B01 Process Acute (SMR01 and GLS) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -64,7 +64,7 @@ GET DATA /TYPE=TXT
       DateofOperation401 A10
       AgeatMidpointofFinancialYear01 F3.0
       ContinuousInpatientStaySMR01incGLS F5.0
-      ContinuousInpatientJourneyMarker01 A5
+      ContinuousInpatientJourneyMarker01 F5.0
       CIJPlannedAdmissionCode01 F1.0
       CIJInpatientDayCaseIdentifierCode01 A2
       CIJTypeofAdmissionCode01 A2
@@ -152,7 +152,7 @@ compute recid = '01B'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
  * Flag GLS records.
@@ -187,9 +187,9 @@ sort cases by uri.
 
 save outfile = !Year_dir + 'acute_temp.zsav'
    /zcompressed.
-  
+
 * Create a file that contains uri, the month number and the net cost and yearstay.
-* Make this look like a 'cross-tab' ready for matching back To the acute_temp file. 
+* Make this look like a 'cross-tab' ready for matching back To the acute_temp file.
 get file = !Year_dir + 'acute_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -222,7 +222,7 @@ aggregate outfile = !Year_dir + 'acute_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 
 match files file = !Year_dir + 'acute_temp.zsav'
@@ -335,7 +335,7 @@ save outfile = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'
     cij_pattype_code
     cij_adm_spec
     cij_dis_spec
-    CIJ_start_date 
+    CIJ_start_date
     CIJ_end_date
     alcohol_adm
     submis_adm

--- a/2019-20/B02 Process Maternity (SMR02) extract.sps
+++ b/2019-20/B02 Process Maternity (SMR02) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
 ********************************************************************************************************.
@@ -11,7 +11,7 @@ GET DATA  /TYPE = TXT
     /QUALIFIER = '"'
     /ARRANGEMENT = DELIMITED
     /FIRSTCASE = 2
-    /VARIABLES = 
+    /VARIABLES =
     CostsFinancialYear A4
     DateofAdmissionFullDate A10
     DateofDischargeFullDate A10
@@ -37,7 +37,7 @@ GET DATA  /TYPE = TXT
     DischargeTransfertoCodenew A2
     DischargedtoLocationCode A5
     ConditionOnDischargeCode F1.0
-    ContinuousInpatientJourneyMarker A5
+    ContinuousInpatientJourneyMarker F5.0
     CIJPlannedAdmissionCode F1.0
     CIJInpatientDayCaseIdentifierCode A2
     CIJTypeofAdmissionCode A2
@@ -159,10 +159,10 @@ for month in (4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3):
 
     # Set up the syntax
     syntax = "!BedDaysPerMonth Month_abbr = " + month_name[month][:3]
-    
+
     # Use the correct admission and discharge variables
     syntax +=  " AdmissionVar = record_keydate1 DischargeVar = record_keydate2."
-    
+
     # print the syntax to the screen
     print(syntax)
 

--- a/2019-20/B04 Process Mental Health (SMR04) extract.sps
+++ b/2019-20/B04 Process Mental Health (SMR04) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -54,7 +54,7 @@ GET DATA  /TYPE=TXT
       AdmissionDiagnosis3Code6char A6
       AdmissionDiagnosis4Code6char A6
       AgeatMidpointofFinancialYear04 F3.0
-      ContinuousInpatientJourneyMarker04 A5
+      ContinuousInpatientJourneyMarker04 F5.0
       CIJPlannedAdmissionCode04 F1.0
       CIJInpatientDayCaseIdentifierCode04 A2
       CIJTypeofAdmissionCode04 A7
@@ -74,7 +74,7 @@ GET DATA  /TYPE=TXT
 CACHE.
 Execute.
 
-* SMR04 specific variables need to be added in here. 
+* SMR04 specific variables need to be added in here.
 rename variables
     AdmissionDiagnosis1Code6char = adcon1
     AdmissionDiagnosis2Code6char = adcon2
@@ -139,7 +139,7 @@ compute ipdc = 'I'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
 if (CIJInpatientDayCaseIdentifierCode04 EQ 'MH') cij_ipdc = 'I'.
@@ -160,11 +160,11 @@ alter type cij_admtype (A2).
 
 sort cases by uri.
 
-* need to add in SMR04 specific variables in to here. 
+* need to add in SMR04 specific variables in to here.
 save outfile = !Year_dir + 'mh_temp.zsav'
    /zcompressed.
-  
-* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file. 
+
+* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file.
 get file = !Year_dir + 'mh_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -197,7 +197,7 @@ aggregate outfile = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 match files file = !Year_dir + 'mh_temp.zsav'
    /table = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'

--- a/2019-20/C01 Make Episode File.sps
+++ b/2019-20/C01 Make Episode File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
@@ -151,8 +151,8 @@ save outfile = !Year_dir + "temp-source-episode-file-Non-CIJ-" + !FY + ".zsav"
 select if any(recid, "01B", "04B", "GLS", "02B").
 
 * Fill in the blank CIJ markers.
-do if (chi ne lag(chi)) AND cij_marker = "" AND chi NE "".
-    compute cij_marker= "1".
+do if (chi ne lag(chi)) AND sysmis(cij_marker) AND chi NE "".
+    compute cij_marker= 1.
 end if.
 
 * Populate ipdc for maternity records.

--- a/2019-20/C02 Link Delayed Discharge episodes.sps
+++ b/2019-20/C02 Link Delayed Discharge episodes.sps
@@ -312,7 +312,7 @@ add files
     /File =  !Year_dir + "DD_for_source-20" + !FY + ".zsav"
     /by chi keydate1_dateformat.
 
-Do if chi NE "" and cij_marker NE "".
+Do if chi NE "" and cij_marker NE sysmis(cij_marker).
     Compute has_delay = SMRType = "DD-CIJ".
 End if.
 

--- a/2019-20/C02 Link Delayed Discharge episodes.sps
+++ b/2019-20/C02 Link Delayed Discharge episodes.sps
@@ -16,11 +16,8 @@ save outfile =  !Year_dir + "slf_reduced_for_DD.zsav"
 get file =  !Year_dir + "slf_reduced_for_DD.zsav".
 
 * Create a copy of the CIJ marker.
-String temp_cij_marker (A5).
+Numeric temp_cij_marker (F5.0).
 Compute temp_cij_marker = cij_marker.
-
-* Set blank to be user missing (important for later).
-Missing Values temp_cij_marker ("     ").
 
 * Add all files together.
 add files
@@ -56,7 +53,7 @@ Do if chi = lag(chi) and recid = "DD" and lag(recid) = "04B" and sysmiss(keydate
 End if.
 
 * Use Min and Max CIJ dates to fill in temp_cij_marker - where possible - DD episodes with no CIJ.
-Do if chi = lag(chi) and missing(temp_cij_marker).
+Do if chi = lag(chi) and sysmis(temp_cij_marker).
     * Create flags simply to check rows where CIJ markers are being added.
     * don't expect any of these.
     compute Flag_1 = 0.
@@ -107,7 +104,7 @@ End if.
 * Sort in the opposite direction.
 sort cases by chi (A) keydate1_dateformat (D) order (A).
 * If DD record date ends within CIJ dates but starts before.
-Do if recid = 'DD' and chi = lag(chi) and missing(temp_cij_marker).
+Do if recid = 'DD' and chi = lag(chi) and sysmis(temp_cij_marker).
     Compute Flag_4 = 0.
     Do if keydate1_dateformat LE lag(CIJ_start_date) and Range(keydate2_dateformat, lag(CIJ_start_date) - time.days(1), lag(CIJ_end_date) + time.days(1)).
         Compute Flag_4 = 1.
@@ -173,7 +170,7 @@ Variable labels
     no_cij "no-CIJ attached".
 
 * Flag DDs which don't seem to have an associated hospital stay.
-if missing(temp_cij_marker) and recid = "DD" no_cij = 1.
+if sysmis(temp_cij_marker) and recid = "DD" no_cij = 1.
 
 save outfile = !Year_dir + "DD_Temp-2.zsav"
     /zcompressed.

--- a/2019-20/C03 Link Homelessness.sps
+++ b/2019-20/C03 Link Homelessness.sps
@@ -26,7 +26,7 @@ aggregate
     /max_records = max(num_records).
 
  * Assuming it must be <=9.
-Alter Type max_records (F1.0).
+Alter Type max_records (AMIN).
 
  * Ugly hack because SPSS...
  * Take the max_records number and generate two macros using this.

--- a/2019-20/C07 Calculate pathways cohorts.sps
+++ b/2019-20/C07 Calculate pathways cohorts.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * Cohort Syntax.
 * Andrew Mooney.
 * Feb 2017.
@@ -286,6 +286,9 @@ If any(recid, "AE2", "OoH", "SAS", "N24") AE2_Cost = Cost_Total_Net.
 * Include CMH here?.
 If recid = "DN" Community_Health_Cost = Cost_Total_Net.
 If op1a ne '' Operation_Flag = 1.
+
+* Convert cij_marker to string so we can merge it with recid.
+Alter type cij_marker (A7).
 
 Do if cij_marker NE "".
     Compute cij_Attendance = 1.

--- a/2019-20/D01 Make Individual File.sps
+++ b/2019-20/D01 Make Individual File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * We create a row per chi by producing various summaries from the episode file.
 
 * Produced, based on the original, by James McMahon.
@@ -63,7 +63,7 @@ add files file = *
     /by CHI cij_marker
     /First = Distinct_CIJ.
 
-If cij_marker = "" Distinct_CIJ = 0.
+If sysmis(cij_marker) Distinct_CIJ = 0.
 
 Do if cij_pattype_code = 0.
     Compute CIJ_non_el = Distinct_CIJ.

--- a/2020-21/B01 Process Acute (SMR01 and GLS) extract.sps
+++ b/2020-21/B01 Process Acute (SMR01 and GLS) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -64,7 +64,7 @@ GET DATA /TYPE=TXT
       DateofOperation401 A10
       AgeatMidpointofFinancialYear01 F3.0
       ContinuousInpatientStaySMR01incGLS F5.0
-      ContinuousInpatientJourneyMarker01 A5
+      ContinuousInpatientJourneyMarker01 F5.0
       CIJPlannedAdmissionCode01 F1.0
       CIJInpatientDayCaseIdentifierCode01 A2
       CIJTypeofAdmissionCode01 A2
@@ -152,7 +152,7 @@ compute recid = '01B'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
  * Flag GLS records.
@@ -187,9 +187,9 @@ sort cases by uri.
 
 save outfile = !Year_dir + 'acute_temp.zsav'
    /zcompressed.
-  
+
 * Create a file that contains uri, the month number and the net cost and yearstay.
-* Make this look like a 'cross-tab' ready for matching back To the acute_temp file. 
+* Make this look like a 'cross-tab' ready for matching back To the acute_temp file.
 get file = !Year_dir + 'acute_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -222,7 +222,7 @@ aggregate outfile = !Year_dir + 'acute_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 
 match files file = !Year_dir + 'acute_temp.zsav'
@@ -335,7 +335,7 @@ save outfile = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'
     cij_pattype_code
     cij_adm_spec
     cij_dis_spec
-    CIJ_start_date 
+    CIJ_start_date
     CIJ_end_date
     alcohol_adm
     submis_adm

--- a/2020-21/B02 Process Maternity (SMR02) extract.sps
+++ b/2020-21/B02 Process Maternity (SMR02) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
 ********************************************************************************************************.
@@ -11,7 +11,7 @@ GET DATA  /TYPE = TXT
     /QUALIFIER = '"'
     /ARRANGEMENT = DELIMITED
     /FIRSTCASE = 2
-    /VARIABLES = 
+    /VARIABLES =
     CostsFinancialYear A4
     DateofAdmissionFullDate A10
     DateofDischargeFullDate A10
@@ -37,7 +37,7 @@ GET DATA  /TYPE = TXT
     DischargeTransfertoCodenew A2
     DischargedtoLocationCode A5
     ConditionOnDischargeCode F1.0
-    ContinuousInpatientJourneyMarker A5
+    ContinuousInpatientJourneyMarker F5.0
     CIJPlannedAdmissionCode F1.0
     CIJInpatientDayCaseIdentifierCode A2
     CIJTypeofAdmissionCode A2
@@ -159,10 +159,10 @@ for month in (4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3):
 
     # Set up the syntax
     syntax = "!BedDaysPerMonth Month_abbr = " + month_name[month][:3]
-    
+
     # Use the correct admission and discharge variables
     syntax +=  " AdmissionVar = record_keydate1 DischargeVar = record_keydate2."
-    
+
     # print the syntax to the screen
     print(syntax)
 

--- a/2020-21/B04 Process Mental Health (SMR04) extract.sps
+++ b/2020-21/B04 Process Mental Health (SMR04) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -54,7 +54,7 @@ GET DATA  /TYPE=TXT
       AdmissionDiagnosis3Code6char A6
       AdmissionDiagnosis4Code6char A6
       AgeatMidpointofFinancialYear04 F3.0
-      ContinuousInpatientJourneyMarker04 A5
+      ContinuousInpatientJourneyMarker04 F5.0
       CIJPlannedAdmissionCode04 F1.0
       CIJInpatientDayCaseIdentifierCode04 A2
       CIJTypeofAdmissionCode04 A7
@@ -74,7 +74,7 @@ GET DATA  /TYPE=TXT
 CACHE.
 Execute.
 
-* SMR04 specific variables need to be added in here. 
+* SMR04 specific variables need to be added in here.
 rename variables
     AdmissionDiagnosis1Code6char = adcon1
     AdmissionDiagnosis2Code6char = adcon2
@@ -139,7 +139,7 @@ compute ipdc = 'I'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
 if (CIJInpatientDayCaseIdentifierCode04 EQ 'MH') cij_ipdc = 'I'.
@@ -160,11 +160,11 @@ alter type cij_admtype (A2).
 
 sort cases by uri.
 
-* need to add in SMR04 specific variables in to here. 
+* need to add in SMR04 specific variables in to here.
 save outfile = !Year_dir + 'mh_temp.zsav'
    /zcompressed.
-  
-* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file. 
+
+* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file.
 get file = !Year_dir + 'mh_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -197,7 +197,7 @@ aggregate outfile = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 match files file = !Year_dir + 'mh_temp.zsav'
    /table = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'

--- a/2020-21/C01 Make Episode File.sps
+++ b/2020-21/C01 Make Episode File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
@@ -151,8 +151,8 @@ save outfile = !Year_dir + "temp-source-episode-file-Non-CIJ-" + !FY + ".zsav"
 select if any(recid, "01B", "04B", "GLS", "02B").
 
 * Fill in the blank CIJ markers.
-do if (chi ne lag(chi)) AND cij_marker = "" AND chi NE "".
-    compute cij_marker= "1".
+do if (chi ne lag(chi)) AND sysmis(cij_marker) AND chi NE "".
+    compute cij_marker= 1.
 end if.
 
 * Populate ipdc for maternity records.

--- a/2020-21/C02 Link Delayed Discharge episodes.sps
+++ b/2020-21/C02 Link Delayed Discharge episodes.sps
@@ -312,7 +312,7 @@ add files
     /File =  !Year_dir + "DD_for_source-20" + !FY + ".zsav"
     /by chi keydate1_dateformat.
 
-Do if chi NE "" and cij_marker NE "".
+Do if chi NE "" and cij_marker NE sysmis(cij_marker).
     Compute has_delay = SMRType = "DD-CIJ".
 End if.
 

--- a/2020-21/C02 Link Delayed Discharge episodes.sps
+++ b/2020-21/C02 Link Delayed Discharge episodes.sps
@@ -16,11 +16,8 @@ save outfile =  !Year_dir + "slf_reduced_for_DD.zsav"
 get file =  !Year_dir + "slf_reduced_for_DD.zsav".
 
 * Create a copy of the CIJ marker.
-String temp_cij_marker (A5).
+Numeric temp_cij_marker (F5.0).
 Compute temp_cij_marker = cij_marker.
-
-* Set blank to be user missing (important for later).
-Missing Values temp_cij_marker ("     ").
 
 * Add all files together.
 add files
@@ -56,7 +53,7 @@ Do if chi = lag(chi) and recid = "DD" and lag(recid) = "04B" and sysmiss(keydate
 End if.
 
 * Use Min and Max CIJ dates to fill in temp_cij_marker - where possible - DD episodes with no CIJ.
-Do if chi = lag(chi) and missing(temp_cij_marker).
+Do if chi = lag(chi) and sysmis(temp_cij_marker).
     * Create flags simply to check rows where CIJ markers are being added.
     * don't expect any of these.
     compute Flag_1 = 0.
@@ -107,7 +104,7 @@ End if.
 * Sort in the opposite direction.
 sort cases by chi (A) keydate1_dateformat (D) order (A).
 * If DD record date ends within CIJ dates but starts before.
-Do if recid = 'DD' and chi = lag(chi) and missing(temp_cij_marker).
+Do if recid = 'DD' and chi = lag(chi) and sysmis(temp_cij_marker).
     Compute Flag_4 = 0.
     Do if keydate1_dateformat LE lag(CIJ_start_date) and Range(keydate2_dateformat, lag(CIJ_start_date) - time.days(1), lag(CIJ_end_date) + time.days(1)).
         Compute Flag_4 = 1.
@@ -173,7 +170,7 @@ Variable labels
     no_cij "no-CIJ attached".
 
 * Flag DDs which don't seem to have an associated hospital stay.
-if missing(temp_cij_marker) and recid = "DD" no_cij = 1.
+if sysmis(temp_cij_marker) and recid = "DD" no_cij = 1.
 
 save outfile = !Year_dir + "DD_Temp-2.zsav"
     /zcompressed.

--- a/2020-21/C03 Link Homelessness.sps
+++ b/2020-21/C03 Link Homelessness.sps
@@ -26,7 +26,7 @@ aggregate
     /max_records = max(num_records).
 
  * Assuming it must be <=9.
-Alter Type max_records (F1.0).
+Alter Type max_records (AMIN).
 
  * Ugly hack because SPSS...
  * Take the max_records number and generate two macros using this.

--- a/2020-21/C07 Calculate pathways cohorts.sps
+++ b/2020-21/C07 Calculate pathways cohorts.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * Cohort Syntax.
 * Andrew Mooney.
 * Feb 2017.
@@ -286,6 +286,9 @@ If any(recid, "AE2", "OoH", "SAS", "N24") AE2_Cost = Cost_Total_Net.
 * Include CMH here?.
 If recid = "DN" Community_Health_Cost = Cost_Total_Net.
 If op1a ne '' Operation_Flag = 1.
+
+* Convert cij_marker to string so we can merge it with recid.
+Alter type cij_marker (A7).
 
 Do if cij_marker NE "".
     Compute cij_Attendance = 1.

--- a/2020-21/D01 Make Individual File.sps
+++ b/2020-21/D01 Make Individual File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * We create a row per chi by producing various summaries from the episode file.
 
 * Produced, based on the original, by James McMahon.
@@ -63,7 +63,7 @@ add files file = *
     /by CHI cij_marker
     /First = Distinct_CIJ.
 
-If cij_marker = "" Distinct_CIJ = 0.
+If sysmis(cij_marker) Distinct_CIJ = 0.
 
 Do if cij_pattype_code = 0.
     Compute CIJ_non_el = Distinct_CIJ.

--- a/2021-22/B01 Process Acute (SMR01 and GLS) extract.sps
+++ b/2021-22/B01 Process Acute (SMR01 and GLS) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -64,7 +64,7 @@ GET DATA /TYPE=TXT
       DateofOperation401 A10
       AgeatMidpointofFinancialYear01 F3.0
       ContinuousInpatientStaySMR01incGLS F5.0
-      ContinuousInpatientJourneyMarker01 A5
+      ContinuousInpatientJourneyMarker01 F5.0
       CIJPlannedAdmissionCode01 F1.0
       CIJInpatientDayCaseIdentifierCode01 A2
       CIJTypeofAdmissionCode01 A2
@@ -152,7 +152,7 @@ compute recid = '01B'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
  * Flag GLS records.
@@ -187,9 +187,9 @@ sort cases by uri.
 
 save outfile = !Year_dir + 'acute_temp.zsav'
    /zcompressed.
-  
+
 * Create a file that contains uri, the month number and the net cost and yearstay.
-* Make this look like a 'cross-tab' ready for matching back To the acute_temp file. 
+* Make this look like a 'cross-tab' ready for matching back To the acute_temp file.
 get file = !Year_dir + 'acute_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -222,7 +222,7 @@ aggregate outfile = !Year_dir + 'acute_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 
 match files file = !Year_dir + 'acute_temp.zsav'
@@ -335,7 +335,7 @@ save outfile = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'
     cij_pattype_code
     cij_adm_spec
     cij_dis_spec
-    CIJ_start_date 
+    CIJ_start_date
     CIJ_end_date
     alcohol_adm
     submis_adm

--- a/2021-22/B02 Process Maternity (SMR02) extract.sps
+++ b/2021-22/B02 Process Maternity (SMR02) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
 ********************************************************************************************************.
@@ -11,7 +11,7 @@ GET DATA  /TYPE = TXT
     /QUALIFIER = '"'
     /ARRANGEMENT = DELIMITED
     /FIRSTCASE = 2
-    /VARIABLES = 
+    /VARIABLES =
     CostsFinancialYear A4
     DateofAdmissionFullDate A10
     DateofDischargeFullDate A10
@@ -37,7 +37,7 @@ GET DATA  /TYPE = TXT
     DischargeTransfertoCodenew A2
     DischargedtoLocationCode A5
     ConditionOnDischargeCode F1.0
-    ContinuousInpatientJourneyMarker A5
+    ContinuousInpatientJourneyMarker F5.0
     CIJPlannedAdmissionCode F1.0
     CIJInpatientDayCaseIdentifierCode A2
     CIJTypeofAdmissionCode A2
@@ -159,10 +159,10 @@ for month in (4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3):
 
     # Set up the syntax
     syntax = "!BedDaysPerMonth Month_abbr = " + month_name[month][:3]
-    
+
     # Use the correct admission and discharge variables
     syntax +=  " AdmissionVar = record_keydate1 DischargeVar = record_keydate2."
-    
+
     # print the syntax to the screen
     print(syntax)
 

--- a/2021-22/B04 Process Mental Health (SMR04) extract.sps
+++ b/2021-22/B04 Process Mental Health (SMR04) extract.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 
 ********************************************************************************************************.
  * Run 01-Set up Macros first!.
@@ -54,7 +54,7 @@ GET DATA  /TYPE=TXT
       AdmissionDiagnosis3Code6char A6
       AdmissionDiagnosis4Code6char A6
       AgeatMidpointofFinancialYear04 F3.0
-      ContinuousInpatientJourneyMarker04 A5
+      ContinuousInpatientJourneyMarker04 F5.0
       CIJPlannedAdmissionCode04 F1.0
       CIJInpatientDayCaseIdentifierCode04 A2
       CIJTypeofAdmissionCode04 A7
@@ -74,7 +74,7 @@ GET DATA  /TYPE=TXT
 CACHE.
 Execute.
 
-* SMR04 specific variables need to be added in here. 
+* SMR04 specific variables need to be added in here.
 rename variables
     AdmissionDiagnosis1Code6char = adcon1
     AdmissionDiagnosis2Code6char = adcon2
@@ -139,7 +139,7 @@ compute ipdc = 'I'.
  * We assume that if it starts with a letter it's an English practice and so recode to 99995.
 Do if Range(char.Substr(gpprac, 1, 1), "A", "Z").
    Compute gpprac = "99995".
-End if. 
+End if.
 Alter Type GPprac (F5.0).
 
 if (CIJInpatientDayCaseIdentifierCode04 EQ 'MH') cij_ipdc = 'I'.
@@ -160,11 +160,11 @@ alter type cij_admtype (A2).
 
 sort cases by uri.
 
-* need to add in SMR04 specific variables in to here. 
+* need to add in SMR04 specific variables in to here.
 save outfile = !Year_dir + 'mh_temp.zsav'
    /zcompressed.
-  
-* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file. 
+
+* Create a file that contains uri and costs month and net cost. Make this look like a 'cross-tab' ready for matching back to the acute_temp file.
 get file = !Year_dir + 'mh_temp.zsav'
    /keep uri cost_total_net yearstay costmonthnum.
 
@@ -197,7 +197,7 @@ aggregate outfile = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'
        Sum(apr_beddays may_beddays jun_beddays jul_beddays aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays feb_beddays mar_beddays).
 
 
-* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.  
+* Match this file back to the main acute file and then create totals adding across the months for each of the costs and yearstay variables.
 * Need To reduce each uri to one row only. All columns will have the same information except for the costs month variable.
 match files file = !Year_dir + 'mh_temp.zsav'
    /table = !Year_dir + 'MH_monthly_costs_and_beddays_by_uri.sav'

--- a/2021-22/C01 Make Episode File.sps
+++ b/2021-22/C01 Make Episode File.sps
@@ -155,8 +155,8 @@ save outfile = !Year_dir + "temp-source-episode-file-Non-CIJ-" + !FY + ".zsav"
 select if any(recid, "01B", "04B", "GLS", "02B").
 
 * Fill in the blank CIJ markers.
-do if (chi ne lag(chi)) AND cij_marker = "" AND chi NE "".
-    compute cij_marker= "1".
+do if (chi ne lag(chi)) AND sysmis(cij_marker) AND chi NE "".
+    compute cij_marker= 1.
 end if.
 
 * Populate ipdc for maternity records.

--- a/2021-22/C02 Link Delayed Discharge episodes.sps
+++ b/2021-22/C02 Link Delayed Discharge episodes.sps
@@ -312,7 +312,7 @@ add files
     /File =  !Year_dir + "DD_for_source-20" + !FY + ".zsav"
     /by chi keydate1_dateformat.
 
-Do if chi NE "" and cij_marker NE "".
+Do if chi NE "" and cij_marker NE sysmis(cij_marker).
     Compute has_delay = SMRType = "DD-CIJ".
 End if.
 

--- a/2021-22/C02 Link Delayed Discharge episodes.sps
+++ b/2021-22/C02 Link Delayed Discharge episodes.sps
@@ -16,11 +16,8 @@ save outfile =  !Year_dir + "slf_reduced_for_DD.zsav"
 get file =  !Year_dir + "slf_reduced_for_DD.zsav".
 
 * Create a copy of the CIJ marker.
-String temp_cij_marker (A5).
+Numeric temp_cij_marker (F5.0).
 Compute temp_cij_marker = cij_marker.
-
-* Set blank to be user missing (important for later).
-Missing Values temp_cij_marker ("     ").
 
 * Add all files together.
 add files
@@ -56,7 +53,7 @@ Do if chi = lag(chi) and recid = "DD" and lag(recid) = "04B" and sysmiss(keydate
 End if.
 
 * Use Min and Max CIJ dates to fill in temp_cij_marker - where possible - DD episodes with no CIJ.
-Do if chi = lag(chi) and missing(temp_cij_marker).
+Do if chi = lag(chi) and sysmis(temp_cij_marker).
     * Create flags simply to check rows where CIJ markers are being added.
     * don't expect any of these.
     compute Flag_1 = 0.
@@ -107,7 +104,7 @@ End if.
 * Sort in the opposite direction.
 sort cases by chi (A) keydate1_dateformat (D) order (A).
 * If DD record date ends within CIJ dates but starts before.
-Do if recid = 'DD' and chi = lag(chi) and missing(temp_cij_marker).
+Do if recid = 'DD' and chi = lag(chi) and sysmis(temp_cij_marker).
     Compute Flag_4 = 0.
     Do if keydate1_dateformat LE lag(CIJ_start_date) and Range(keydate2_dateformat, lag(CIJ_start_date) - time.days(1), lag(CIJ_end_date) + time.days(1)).
         Compute Flag_4 = 1.
@@ -173,7 +170,7 @@ Variable labels
     no_cij "no-CIJ attached".
 
 * Flag DDs which don't seem to have an associated hospital stay.
-if missing(temp_cij_marker) and recid = "DD" no_cij = 1.
+if sysmis(temp_cij_marker) and recid = "DD" no_cij = 1.
 
 save outfile = !Year_dir + "DD_Temp-2.zsav"
     /zcompressed.

--- a/2021-22/C03 Link Homelessness.sps
+++ b/2021-22/C03 Link Homelessness.sps
@@ -26,7 +26,7 @@ aggregate
     /max_records = max(num_records).
 
  * Assuming it must be <=9.
-Alter Type max_records (F1.0).
+Alter Type max_records (AMIN).
 
  * Ugly hack because SPSS...
  * Take the max_records number and generate two macros using this.

--- a/2021-22/C07 Calculate pathways cohorts.sps
+++ b/2021-22/C07 Calculate pathways cohorts.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * Cohort Syntax.
 * Andrew Mooney.
 * Feb 2017.
@@ -286,6 +286,9 @@ If any(recid, "AE2", "OoH", "SAS", "N24") AE2_Cost = Cost_Total_Net.
 * Include CMH here?.
 If recid = "DN" Community_Health_Cost = Cost_Total_Net.
 If op1a ne '' Operation_Flag = 1.
+
+* Convert cij_marker to string so we can merge it with recid.
+Alter type cij_marker (A7).
 
 Do if cij_marker NE "".
     Compute cij_Attendance = 1.

--- a/2021-22/D01 Make Individual File.sps
+++ b/2021-22/D01 Make Individual File.sps
@@ -1,4 +1,4 @@
-﻿* Encoding: UTF-8.
+* Encoding: UTF-8.
 * We create a row per chi by producing various summaries from the episode file.
 
 * Produced, based on the original, by James McMahon.
@@ -63,7 +63,7 @@ add files file = *
     /by CHI cij_marker
     /First = Distinct_CIJ.
 
-If cij_marker = "" Distinct_CIJ = 0.
+If sysmis(cij_marker) Distinct_CIJ = 0.
 
 Do if cij_pattype_code = 0.
     Compute CIJ_non_el = Distinct_CIJ.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# March 2022 Update - Draft
+# June 2022 Update - Unreleased
+* Cij_marker is now a numeric instead of a string which changes empty strings to missing instead of blank using sysmis.
+
+# March 2022 Update - Released 17-Mar-2022
 * NSU extract now available for 2014/15.
 * New variable `gender` included in NSU extract.
 * Now using Social Care data up to 2021/22 Q2.


### PR DESCRIPTION
I did a search for all instances of `cij_marker` in the SPSS code and then checked them all for types.

I've changed the type from String to numeric on the initial read.

I also changed any instances where the `cij_marker` was used. None of this has been tested.

@Jennit07 if you can check and test this (to some extent) that would be great. You can approve but please don't merge until we decide if we're actually using it! The alternative to this would be to set the `cij_marker` to be `(A5)` which would be much fewer changes, but leave it as a string.

Closes #213 