### PR TITLE
Update `cij_ppa` logic to work with the numeric `cij_marker`

### DIFF
--- a/2014-15/C01 Make Episode File.sps
+++ b/2014-15/C01 Make Episode File.sps
@@ -197,7 +197,7 @@ Numeric PPA (F1.0).
 * Acute records.
 Do if any (recid, "01B", "02B", "04B", "GLS").
     * First record in CIJ.
-    Do if (chi NE lag(chi) or (chi = lag(chi) and cij_marker NE lag(cij_marker))).
+    Do if (chi NE lag(chi) or (chi = lag(chi) and ((cij_marker NE lag(cij_marker)) or (Not(sysmis(cij_marker)) and sysmis(lag(cij_marker)))))).
         * Non-elective original admission.
         Do if cij_pattype = "Non-Elective".
             * Initialise PPA flag for relevant records.

--- a/2015-16/C01 Make Episode File.sps
+++ b/2015-16/C01 Make Episode File.sps
@@ -201,7 +201,7 @@ Numeric PPA (F1.0).
 * Acute records.
 Do if any (recid, "01B", "02B", "04B", "GLS").
     * First record in CIJ.
-    Do if (chi NE lag(chi) or (chi = lag(chi) and cij_marker NE lag(cij_marker))).
+    Do if (chi NE lag(chi) or (chi = lag(chi) and ((cij_marker NE lag(cij_marker)) or (Not(sysmis(cij_marker)) and sysmis(lag(cij_marker)))))).
         * Non-elective original admission.
         Do if cij_pattype = "Non-Elective".
             * Initialise PPA flag for relevant records.

--- a/2016-17/C01 Make Episode File.sps
+++ b/2016-17/C01 Make Episode File.sps
@@ -204,7 +204,7 @@ Numeric PPA (F1.0).
 * Acute records.
 Do if any (recid, "01B", "02B", "04B", "GLS").
     * First record in CIJ.
-    Do if (chi NE lag(chi) or (chi = lag(chi) and cij_marker NE lag(cij_marker))).
+    Do if (chi NE lag(chi) or (chi = lag(chi) and ((cij_marker NE lag(cij_marker)) or (Not(sysmis(cij_marker)) and sysmis(lag(cij_marker)))))).
         * Non-elective original admission.
         Do if cij_pattype = "Non-Elective".
             * Initialise PPA flag for relevant records.

--- a/2017-18/C01 Make Episode File.sps
+++ b/2017-18/C01 Make Episode File.sps
@@ -1,4 +1,4 @@
-* Encoding: UTF-8.
+﻿* Encoding: UTF-8.
 
 ********************************************************************************************************.
 * Run 01-Set up Macros first!.
@@ -212,7 +212,7 @@ Numeric PPA (F1.0).
 * Acute records.
 Do if any (recid, "01B", "02B", "04B", "GLS").
     * First record in CIJ.
-    Do if (chi NE lag(chi) or (chi = lag(chi) and cij_marker NE lag(cij_marker))).
+    Do if (chi NE lag(chi) or (chi = lag(chi) and ((cij_marker NE lag(cij_marker)) or (Not(sysmis(cij_marker)) and sysmis(lag(cij_marker)))))).
         * Non-elective original admission.
         Do if cij_pattype = "Non-Elective".
             * Initialise PPA flag for relevant records.

--- a/2018-19/C01 Make Episode File.sps
+++ b/2018-19/C01 Make Episode File.sps
@@ -205,7 +205,7 @@ Numeric PPA (F1.0).
 * Acute records.
 Do if any (recid, "01B", "02B", "04B", "GLS").
     * First record in CIJ.
-    Do if (chi NE lag(chi) or (chi = lag(chi) and cij_marker NE lag(cij_marker))).
+    Do if (chi NE lag(chi) or (chi = lag(chi) and ((cij_marker NE lag(cij_marker)) or (Not(sysmis(cij_marker)) and sysmis(lag(cij_marker)))))).
         * Non-elective original admission.
         Do if cij_pattype = "Non-Elective".
             * Initialise PPA flag for relevant records.

--- a/2019-20/C01 Make Episode File.sps
+++ b/2019-20/C01 Make Episode File.sps
@@ -205,7 +205,7 @@ Numeric PPA (F1.0).
 * Acute records.
 Do if any (recid, "01B", "02B", "04B", "GLS").
     * First record in CIJ.
-    Do if (chi NE lag(chi) or (chi = lag(chi) and cij_marker NE lag(cij_marker))).
+    Do if (chi NE lag(chi) or (chi = lag(chi) and ((cij_marker NE lag(cij_marker)) or (Not(sysmis(cij_marker)) and sysmis(lag(cij_marker)))))).
         * Non-elective original admission.
         Do if cij_pattype = "Non-Elective".
             * Initialise PPA flag for relevant records.

--- a/2020-21/C01 Make Episode File.sps
+++ b/2020-21/C01 Make Episode File.sps
@@ -205,7 +205,7 @@ Numeric PPA (F1.0).
 * Acute records.
 Do if any (recid, "01B", "02B", "04B", "GLS").
     * First record in CIJ.
-    Do if (chi NE lag(chi) or (chi = lag(chi) and cij_marker NE lag(cij_marker))).
+    Do if (chi NE lag(chi) or (chi = lag(chi) and ((cij_marker NE lag(cij_marker)) or (Not(sysmis(cij_marker)) and sysmis(lag(cij_marker)))))).
         * Non-elective original admission.
         Do if cij_pattype = "Non-Elective".
             * Initialise PPA flag for relevant records.

--- a/2021-22/C01 Make Episode File.sps
+++ b/2021-22/C01 Make Episode File.sps
@@ -209,7 +209,7 @@ Numeric PPA (F1.0).
 * Acute records.
 Do if any (recid, "01B", "02B", "04B", "GLS").
     * First record in CIJ.
-    Do if (chi NE lag(chi) or (chi = lag(chi) and cij_marker NE lag(cij_marker))).
+    Do if (chi NE lag(chi) or (chi = lag(chi) and ((cij_marker NE lag(cij_marker)) or (Not(sysmis(cij_marker)) and sysmis(lag(cij_marker)))))).
         * Non-elective original admission.
         Do if cij_pattype = "Non-Elective".
             * Initialise PPA flag for relevant records.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,9 @@
 * Fixed a bug where CH costs was not referring to end of year. 
   * eg. 2018 costs relates to 2017/18
 * The changes to Homelessness described in the March update have been properly implemented.
-* Cij_marker is now a numeric instead of a string which changes empty strings to missing instead of blank using sysmis.
+* `cij_marker` is now a numeric instead of a string which changes empty strings to missing instead of blank using sysmis.
+  * Check code of the form `cij_marker = "x"`. `x` now needs to be a numeric.
+  * Check code of the form `cij_maker = lag(cij_marker)`. If the previous `cij_marker` is missing, the expression will fail, previously it would have compared to an empty string.
 * We now match on clusters from the past 5 years, rather than just the latest (quarterly) release. This means that more GP practices will be assigned to a cluster (even if the code has been retired at the time of the SLF refresh).
 * The ACaDMe variable `glsrecord` is now the only thing we use to determine if an episode should have recid `01B` (Acute) or `GLS`. Previously `lineno` was also used.
 * Fixed a bug where we were overcounting preventable beddays in the individual file.


### PR DESCRIPTION
A crosstab showing the issue, where `cij_ppa_2` is the 'corrected' logic. System missing has been set to `-99` to display in the SPSS crosstab. Notice that a lot of CIJs which were getting flagged as `sysmis` are now being flagged (properly) as `1` or `0`
<img width="395" alt="image" src="https://user-images.githubusercontent.com/5982260/170243257-9acdc56e-41b7-4abf-96d5-eba0ae13bc16.png">
