### PR TITLE
Update monthly cost variables for all changed costs

### DIFF
--- a/2018-19/B01a Fix C3 costs.sps
+++ b/2018-19/B01a Fix C3 costs.sps
@@ -2,25 +2,28 @@
 * Open processed Acute extract.
 get file = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'.
 
-* Apply new costs, these are taken from the 2017/18 file.
-* Either the average cost per day for inpatient, or the average daycase cost for daycase.
-* Using the A11H DC cost for A210H as it had low activity in 2017/18.
-* Using the 2016/17 DC cost for V217H as it as no activity for 17/18 onwards (just in case).
-Do if recid = "01B" and spec = "C3".
-    * NHS Ayrshire and Arran.
-    Do if hbtreatcode = "S08000015".
-        Do if location = "A111H".
-            If ipdc = "D" cost_total_net = 521.38.
-            If ipdc = "I" cost_total_net = 2309.26 * yearstay.
-        Else if location = "A210H".
-            If ipdc = "D" cost_total_net = 521.38.
-            If ipdc = "I" cost_total_net = 2460.63 * yearstay.
-        End if.
-        * NHS Forth Valley.
-    Else if hbtreatcode = "S08000019".
-        Do if location = "V217H".
-            If ipdc = "D" cost_total_net = 1492.83.
-            If ipdc = "I" cost_total_net = 3179.24 * yearstay.
+* Making cost changes for 18/19 and other years which are using the 18/19 costs, currently all years.
+Do if year >= "1819".
+    * Apply new costs, these are taken from the 2017/18 file.
+    * Either the average cost per day for inpatient, or the average daycase cost for daycase.
+    * Using the A11H DC cost for A210H as it had low activity in 2017/18.
+    * Using the 2016/17 DC cost for V217H as it as no activity for 17/18 onwards (just in case).
+    Do if recid = "01B" and spec = "C3".
+        * NHS Ayrshire and Arran.
+        Do if hbtreatcode = "S08000015".
+            Do if location = "A111H".
+                If ipdc = "D" cost_total_net = 521.38.
+                If ipdc = "I" cost_total_net = 2309.26 * yearstay.
+            Else if location = "A210H".
+                If ipdc = "D" cost_total_net = 521.38.
+                If ipdc = "I" cost_total_net = 2460.63 * yearstay.
+            End if.
+            * NHS Forth Valley.
+        Else if hbtreatcode = "S08000019".
+            Do if location = "V217H".
+                If ipdc = "D" cost_total_net = 1492.83.
+                If ipdc = "I" cost_total_net = 3179.24 * yearstay.
+            End if.
         End if.
     End if.
 End if.
@@ -36,18 +39,20 @@ Do Repeat Beddays = Apr_beddays to Mar_beddays
     /MonthNum = 4 5 6 7 8 9 10 11 12 1 2 3.
 
     * Only re-compute monthly costs where needed.
-    Do if recid = "01B" and spec = "C3" and hbtreatcode = "S08000015".
+    Do if year >= "1819".
+        Do if recid = "01B" and spec = "C3" and any(hbtreatcode, "S08000015", "S08000019") and any(location, "A111H", "A210H", "V217H").
 
-        * Deal with single day episodes (inpatient or daycase).
-        Do if (keydate1_dateformat = keydate2_dateformat).
-            Do if  xdate.Month(keydate1_dateformat) = MonthNum.
-                Compute Cost = cost_total_net.
+            * Deal with single day episodes (inpatient or daycase).
+            Do if (keydate1_dateformat = keydate2_dateformat).
+                Do if  xdate.Month(keydate1_dateformat) = MonthNum.
+                    Compute Cost = cost_total_net.
+                Else.
+                    Compute Cost = 0.
+                End if.
+                * Deal with normal inpatient episodes.
             Else.
-                Compute Cost = 0.
+                Compute Cost = (Beddays / yearstay) * cost_total_net.
             End if.
-            * Deal with normal inpatient episodes.
-        Else.
-            Compute Cost = (Beddays / yearstay) * cost_total_net.
         End if.
     End if.
 End Repeat.

--- a/2019-20/B01a Fix C3 costs.sps
+++ b/2019-20/B01a Fix C3 costs.sps
@@ -2,25 +2,28 @@
 * Open processed Acute extract.
 get file = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'.
 
-* Apply new costs, these are taken from the 2017/18 file.
-* Either the average cost per day for inpatient, or the average daycase cost for daycase.
-* Using the A11H DC cost for A210H as it had low activity in 2017/18.
-* Using the 2016/17 DC cost for V217H as it as no activity for 17/18 onwards (just in case).
-Do if recid = "01B" and spec = "C3".
-    * NHS Ayrshire and Arran.
-    Do if hbtreatcode = "S08000015".
-        Do if location = "A111H".
-            If ipdc = "D" cost_total_net = 521.38.
-            If ipdc = "I" cost_total_net = 2309.26 * yearstay.
-        Else if location = "A210H".
-            If ipdc = "D" cost_total_net = 521.38.
-            If ipdc = "I" cost_total_net = 2460.63 * yearstay.
-        End if.
-        * NHS Forth Valley.
-    Else if hbtreatcode = "S08000019".
-        Do if location = "V217H".
-            If ipdc = "D" cost_total_net = 1492.83.
-            If ipdc = "I" cost_total_net = 3179.24 * yearstay.
+* Making cost changes for 18/19 and other years which are using the 18/19 costs, currently all years.
+Do if year >= "1819".
+    * Apply new costs, these are taken from the 2017/18 file.
+    * Either the average cost per day for inpatient, or the average daycase cost for daycase.
+    * Using the A11H DC cost for A210H as it had low activity in 2017/18.
+    * Using the 2016/17 DC cost for V217H as it as no activity for 17/18 onwards (just in case).
+    Do if recid = "01B" and spec = "C3".
+        * NHS Ayrshire and Arran.
+        Do if hbtreatcode = "S08000015".
+            Do if location = "A111H".
+                If ipdc = "D" cost_total_net = 521.38.
+                If ipdc = "I" cost_total_net = 2309.26 * yearstay.
+            Else if location = "A210H".
+                If ipdc = "D" cost_total_net = 521.38.
+                If ipdc = "I" cost_total_net = 2460.63 * yearstay.
+            End if.
+            * NHS Forth Valley.
+        Else if hbtreatcode = "S08000019".
+            Do if location = "V217H".
+                If ipdc = "D" cost_total_net = 1492.83.
+                If ipdc = "I" cost_total_net = 3179.24 * yearstay.
+            End if.
         End if.
     End if.
 End if.
@@ -36,18 +39,20 @@ Do Repeat Beddays = Apr_beddays to Mar_beddays
     /MonthNum = 4 5 6 7 8 9 10 11 12 1 2 3.
 
     * Only re-compute monthly costs where needed.
-    Do if recid = "01B" and spec = "C3" and hbtreatcode = "S08000015".
+    Do if year >= "1819".
+        Do if recid = "01B" and spec = "C3" and any(hbtreatcode, "S08000015", "S08000019") and any(location, "A111H", "A210H", "V217H").
 
-        * Deal with single day episodes (inpatient or daycase).
-        Do if (keydate1_dateformat = keydate2_dateformat).
-            Do if  xdate.Month(keydate1_dateformat) = MonthNum.
-                Compute Cost = cost_total_net.
+            * Deal with single day episodes (inpatient or daycase).
+            Do if (keydate1_dateformat = keydate2_dateformat).
+                Do if  xdate.Month(keydate1_dateformat) = MonthNum.
+                    Compute Cost = cost_total_net.
+                Else.
+                    Compute Cost = 0.
+                End if.
+                * Deal with normal inpatient episodes.
             Else.
-                Compute Cost = 0.
+                Compute Cost = (Beddays / yearstay) * cost_total_net.
             End if.
-            * Deal with normal inpatient episodes.
-        Else.
-            Compute Cost = (Beddays / yearstay) * cost_total_net.
         End if.
     End if.
 End Repeat.

--- a/2020-21/B01a Fix C3 costs.sps
+++ b/2020-21/B01a Fix C3 costs.sps
@@ -2,25 +2,28 @@
 * Open processed Acute extract.
 get file = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'.
 
-* Apply new costs, these are taken from the 2017/18 file.
-* Either the average cost per day for inpatient, or the average daycase cost for daycase.
-* Using the A11H DC cost for A210H as it had low activity in 2017/18.
-* Using the 2016/17 DC cost for V217H as it as no activity for 17/18 onwards (just in case).
-Do if recid = "01B" and spec = "C3".
-    * NHS Ayrshire and Arran.
-    Do if hbtreatcode = "S08000015".
-        Do if location = "A111H".
-            If ipdc = "D" cost_total_net = 521.38.
-            If ipdc = "I" cost_total_net = 2309.26 * yearstay.
-        Else if location = "A210H".
-            If ipdc = "D" cost_total_net = 521.38.
-            If ipdc = "I" cost_total_net = 2460.63 * yearstay.
-        End if.
-        * NHS Forth Valley.
-    Else if hbtreatcode = "S08000019".
-        Do if location = "V217H".
-            If ipdc = "D" cost_total_net = 1492.83.
-            If ipdc = "I" cost_total_net = 3179.24 * yearstay.
+* Making cost changes for 18/19 and other years which are using the 18/19 costs, currently all years.
+Do if year >= "1819".
+    * Apply new costs, these are taken from the 2017/18 file.
+    * Either the average cost per day for inpatient, or the average daycase cost for daycase.
+    * Using the A11H DC cost for A210H as it had low activity in 2017/18.
+    * Using the 2016/17 DC cost for V217H as it as no activity for 17/18 onwards (just in case).
+    Do if recid = "01B" and spec = "C3".
+        * NHS Ayrshire and Arran.
+        Do if hbtreatcode = "S08000015".
+            Do if location = "A111H".
+                If ipdc = "D" cost_total_net = 521.38.
+                If ipdc = "I" cost_total_net = 2309.26 * yearstay.
+            Else if location = "A210H".
+                If ipdc = "D" cost_total_net = 521.38.
+                If ipdc = "I" cost_total_net = 2460.63 * yearstay.
+            End if.
+            * NHS Forth Valley.
+        Else if hbtreatcode = "S08000019".
+            Do if location = "V217H".
+                If ipdc = "D" cost_total_net = 1492.83.
+                If ipdc = "I" cost_total_net = 3179.24 * yearstay.
+            End if.
         End if.
     End if.
 End if.
@@ -36,18 +39,20 @@ Do Repeat Beddays = Apr_beddays to Mar_beddays
     /MonthNum = 4 5 6 7 8 9 10 11 12 1 2 3.
 
     * Only re-compute monthly costs where needed.
-    Do if recid = "01B" and spec = "C3" and hbtreatcode = "S08000015".
+    Do if year >= "1819".
+        Do if recid = "01B" and spec = "C3" and any(hbtreatcode, "S08000015", "S08000019") and any(location, "A111H", "A210H", "V217H").
 
-        * Deal with single day episodes (inpatient or daycase).
-        Do if (keydate1_dateformat = keydate2_dateformat).
-            Do if  xdate.Month(keydate1_dateformat) = MonthNum.
-                Compute Cost = cost_total_net.
+            * Deal with single day episodes (inpatient or daycase).
+            Do if (keydate1_dateformat = keydate2_dateformat).
+                Do if  xdate.Month(keydate1_dateformat) = MonthNum.
+                    Compute Cost = cost_total_net.
+                Else.
+                    Compute Cost = 0.
+                End if.
+                * Deal with normal inpatient episodes.
             Else.
-                Compute Cost = 0.
+                Compute Cost = (Beddays / yearstay) * cost_total_net.
             End if.
-            * Deal with normal inpatient episodes.
-        Else.
-            Compute Cost = (Beddays / yearstay) * cost_total_net.
         End if.
     End if.
 End Repeat.

--- a/2021-22/B01a Fix C3 costs.sps
+++ b/2021-22/B01a Fix C3 costs.sps
@@ -2,25 +2,28 @@
 * Open processed Acute extract.
 get file = !Year_dir + 'acute_for_source-20' + !FY + '.zsav'.
 
-* Apply new costs, these are taken from the 2017/18 file.
-* Either the average cost per day for inpatient, or the average daycase cost for daycase.
-* Using the A11H DC cost for A210H as it had low activity in 2017/18.
-* Using the 2016/17 DC cost for V217H as it as no activity for 17/18 onwards (just in case).
-Do if recid = "01B" and spec = "C3".
-    * NHS Ayrshire and Arran.
-    Do if hbtreatcode = "S08000015".
-        Do if location = "A111H".
-            If ipdc = "D" cost_total_net = 521.38.
-            If ipdc = "I" cost_total_net = 2309.26 * yearstay.
-        Else if location = "A210H".
-            If ipdc = "D" cost_total_net = 521.38.
-            If ipdc = "I" cost_total_net = 2460.63 * yearstay.
-        End if.
-        * NHS Forth Valley.
-    Else if hbtreatcode = "S08000019".
-        Do if location = "V217H".
-            If ipdc = "D" cost_total_net = 1492.83.
-            If ipdc = "I" cost_total_net = 3179.24 * yearstay.
+* Making cost changes for 18/19 and other years which are using the 18/19 costs, currently all years.
+Do if year >= "1819".
+    * Apply new costs, these are taken from the 2017/18 file.
+    * Either the average cost per day for inpatient, or the average daycase cost for daycase.
+    * Using the A11H DC cost for A210H as it had low activity in 2017/18.
+    * Using the 2016/17 DC cost for V217H as it as no activity for 17/18 onwards (just in case).
+    Do if recid = "01B" and spec = "C3".
+        * NHS Ayrshire and Arran.
+        Do if hbtreatcode = "S08000015".
+            Do if location = "A111H".
+                If ipdc = "D" cost_total_net = 521.38.
+                If ipdc = "I" cost_total_net = 2309.26 * yearstay.
+            Else if location = "A210H".
+                If ipdc = "D" cost_total_net = 521.38.
+                If ipdc = "I" cost_total_net = 2460.63 * yearstay.
+            End if.
+            * NHS Forth Valley.
+        Else if hbtreatcode = "S08000019".
+            Do if location = "V217H".
+                If ipdc = "D" cost_total_net = 1492.83.
+                If ipdc = "I" cost_total_net = 3179.24 * yearstay.
+            End if.
         End if.
     End if.
 End if.
@@ -36,18 +39,20 @@ Do Repeat Beddays = Apr_beddays to Mar_beddays
     /MonthNum = 4 5 6 7 8 9 10 11 12 1 2 3.
 
     * Only re-compute monthly costs where needed.
-    Do if recid = "01B" and spec = "C3" and hbtreatcode = "S08000015".
+    Do if year >= "1819".
+        Do if recid = "01B" and spec = "C3" and any(hbtreatcode, "S08000015", "S08000019") and any(location, "A111H", "A210H", "V217H").
 
-        * Deal with single day episodes (inpatient or daycase).
-        Do if (keydate1_dateformat = keydate2_dateformat).
-            Do if  xdate.Month(keydate1_dateformat) = MonthNum.
-                Compute Cost = cost_total_net.
+            * Deal with single day episodes (inpatient or daycase).
+            Do if (keydate1_dateformat = keydate2_dateformat).
+                Do if  xdate.Month(keydate1_dateformat) = MonthNum.
+                    Compute Cost = cost_total_net.
+                Else.
+                    Compute Cost = 0.
+                End if.
+                * Deal with normal inpatient episodes.
             Else.
-                Compute Cost = 0.
+                Compute Cost = (Beddays / yearstay) * cost_total_net.
             End if.
-            * Deal with normal inpatient episodes.
-        Else.
-            Compute Cost = (Beddays / yearstay) * cost_total_net.
         End if.
     End if.
 End Repeat.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * The ACaDMe variable `glsrecord` is now the only thing we use to determine if an episode should have recid `01B` (Acute) or `GLS`. Previously `lineno` was also used.
 * Fixed a bug where we were overcounting preventable beddays in the individual file.
   * e.g. if a cij had 2 episodes then it would have 2X the correct number of beddays. This is now corrected.
+* We were correcting some costs for FV and A&A (see previous update). `cost_total_net` was being correctly updated, however the monthly cost variables for Forth Valley were not being changed, this is now fixed.
 
 
 # March 2022 Update - Released 17-Mar-2022


### PR DESCRIPTION
The main issue this change fixes is that previously only the monthly variables for A&A were being updated after cost_total_net was for both A&A and FV. This change fixes that.

It also adds some extra selections to make extremely clear what is being affected.

With the new year selector we could in theory run this code on every year as it would only actually do anything for `year >= "1819"`, this is like the R version.