### PR TITLE
Simplify documentation

### DIFF
--- a/R/create_demog_test_flags.R
+++ b/R/create_demog_test_flags.R
@@ -3,7 +3,7 @@
 #' @param data a dataframe containing demographic variables e.g. chi
 #'
 #' @return a dataframe with flag (1 or 0) for each demographic variables.
-#' Missing value flag from \code{\link{is_missing}}
+#' Missing value flag from [is_missing()]
 #' @export
 #'
 #' @family create test flags functions

--- a/R/find_latest_file.R
+++ b/R/find_latest_file.R
@@ -2,16 +2,16 @@
 #'
 #' @description
 #' This will return the latest created file matching
-#' the criteria. It uses \code{\link[fs]{dir_info}} to
+#' the criteria. It uses [fs::dir_info()] to
 #' find the files then picks the one with the latest
 #' \code{birthtime}
 #'
 #' @param dir The directory to look on
-#' @param ... additional arguments passed to \code{\link[fs]{dir_info}}
+#' @param ... additional arguments passed to [fs::dir_info()]
 #' @param recurse Should the function search recursively
 #' through subfolders? The default `TRUE` is to search subfolders.
 #'
-#' @return the \code{\link[fs]{path}} to the file
+#' @return the [fs::path()] to the file
 #' @export
 #'
 #' @examples

--- a/R/get_cohorts_paths.R
+++ b/R/get_cohorts_paths.R
@@ -2,13 +2,13 @@
 #' Cohort lookup
 #'
 #' @param year The year for the cohorts extract
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the Demographics Cohort lookup
 #' as a [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_demog_cohorts_path <- function(year, ...) {
   demog_cohorts_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "Cohorts"),
@@ -23,13 +23,13 @@ get_demog_cohorts_path <- function(year, ...) {
 #' Cohort lookup
 #'
 #' @param year The year for the cohorts extract
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the Service Use Cohort lookup
 #' as a [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_service_use_cohorts_path <- function(year, ...) {
   service_use_cohorts_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "Cohorts"),

--- a/R/get_cohorts_paths.R
+++ b/R/get_cohorts_paths.R
@@ -5,7 +5,7 @@
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
 #' @return The path to the Demographics Cohort lookup
-#' as a \code{\link[fs]{path}}
+#' as a [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.
@@ -26,7 +26,7 @@ get_demog_cohorts_path <- function(year, ...) {
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
 #' @return The path to the Service Use Cohort lookup
-#' as a \code{\link[fs]{path}}
+#' as a [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_costs_paths.R
+++ b/R/get_costs_paths.R
@@ -3,7 +3,7 @@
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #' @param update passed through \code{\link{latest_update}}
 #'
-#' @return The path to the costs lookup as an \code{\link[fs]{path}}
+#' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.
@@ -22,7 +22,7 @@ get_ch_costs_path <- function(..., update = NULL) {
 #' @param ... additional arguments passed to  \code{\link{get_file_path}}
 #' @param update passed through \code{\link{latest_update}}
 #'
-#' @return The path to the costs lookup as an \code{\link[fs]{path}}
+#' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.
@@ -42,7 +42,7 @@ get_dn_costs_path <- function(..., update = NULL) {
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #' @param update passed through \code{\link{latest_update}}
 #'
-#' @return The path to the costs lookup as an \code{\link[fs]{path}}
+#' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_costs_paths.R
+++ b/R/get_costs_paths.R
@@ -1,12 +1,12 @@
 #' Get the full Care Home costs lookup path
 #'
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
-#' @param update passed through \code{\link{latest_update}}
+#' @param ... additional arguments passed to [get_file_path()]
+#' @param update passed through [latest_update()]
 #'
 #' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_ch_costs_path <- function(..., update = NULL) {
   ch_costs_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "Costs"),
@@ -19,13 +19,13 @@ get_ch_costs_path <- function(..., update = NULL) {
 
 #' Get the full District Nursing costs lookup path
 #'
-#' @param ... additional arguments passed to  \code{\link{get_file_path}}
-#' @param update passed through \code{\link{latest_update}}
+#' @param ... additional arguments passed to  [get_file_path()]
+#' @param update passed through [latest_update()]
 #'
 #' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_dn_costs_path <- function(..., update = NULL) {
   dn_costs_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "Costs"),
@@ -39,13 +39,13 @@ get_dn_costs_path <- function(..., update = NULL) {
 
 #' Get the full GP Out of Hours costs lookup path
 #'
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
-#' @param update passed through \code{\link{latest_update}}
+#' @param ... additional arguments passed to [get_file_path()]
+#' @param update passed through [latest_update()]
 #'
 #' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_gp_ooh_costs_path <- function(..., update = NULL) {
   gp_ooh_costs_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "Costs"),

--- a/R/get_dd_path.R
+++ b/R/get_dd_path.R
@@ -5,7 +5,7 @@
 #' defaults to \code{\link{dd_period}}
 #'
 #' @return The path to the latest Delayed Discharges file
-#' as a \code{\link[fs]{path}}
+#' as a [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_dd_path.R
+++ b/R/get_dd_path.R
@@ -1,14 +1,14 @@
 #' Get the Delayed Discharges file path
 #'
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #' @param dd_period The period to use for reading the file,
-#' defaults to \code{\link{dd_period}}
+#' defaults to [dd_period()]
 #'
 #' @return The path to the latest Delayed Discharges file
 #' as a [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_dd_path <- function(..., dd_period = NULL) {
   if (is.null(dd_period)) {
     dd_period <- dd_period()

--- a/R/get_file_paths.R
+++ b/R/get_file_paths.R
@@ -12,7 +12,7 @@
 #' @param file_name The file name (with extension if not supplied to \code{ext})
 #' @param ext The extension (type of the file) - optional
 #' @param check_mode The mode passed to
-#' \code{\link[fs]{file_access}}, defaults to "read"
+#' [fs::file_access()], defaults to "read"
 #' to check that you have read access to the file
 #' @param create Optionally create the file if it doesn't exists,
 #' the default is to only create a file if we set `check_mode = "write"`

--- a/R/get_it_extract_paths.R
+++ b/R/get_it_extract_paths.R
@@ -5,7 +5,7 @@
 #' defaults to \code{\link{it_extract_ref}}
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the LTC extract as an \code{\link[fs]{path}}
+#' @return The path to the LTC extract as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.
@@ -25,7 +25,7 @@ get_it_ltc_path <- function(it_reference = it_extract_ref(), ...) {
 #' defaults to \code{\link{it_extract_ref}}
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the IT Deaths extract as an \code{\link[fs]{path}}
+#' @return The path to the IT Deaths extract as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.
@@ -46,7 +46,7 @@ get_it_deaths_path <-
 #' defaults to \code{\link{it_extract_ref}}
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the PIS extract as an \code{\link[fs]{path}}
+#' @return The path to the PIS extract as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_it_extract_paths.R
+++ b/R/get_it_extract_paths.R
@@ -2,13 +2,13 @@
 #' Long Term Conditions extract
 #'
 #' @param it_reference The IT reference to use,
-#' defaults to \code{\link{it_extract_ref}}
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' defaults to [it_extract_ref()]
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the LTC extract as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_it_ltc_path <- function(it_reference = it_extract_ref(), ...) {
   it_ltc_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "IT_extracts"),
@@ -22,13 +22,13 @@ get_it_ltc_path <- function(it_reference = it_extract_ref(), ...) {
 #' Get the full path to the IT Deaths extract
 #'
 #' @param it_reference The IT reference to use,
-#' defaults to \code{\link{it_extract_ref}}
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' defaults to [it_extract_ref()]
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the IT Deaths extract as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_it_deaths_path <-
   function(it_reference = it_extract_ref(), ...) {
     it_deaths_path <- get_file_path(
@@ -43,13 +43,13 @@ get_it_deaths_path <-
 #'
 #' @param year the year for the required extract
 #' @param it_reference The IT reference to use,
-#' defaults to \code{\link{it_extract_ref}}
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' defaults to [it_extract_ref()]
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the PIS extract as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_it_prescribing_path <-
   function(year, it_reference = it_extract_ref(), ...) {
     it_extracts_dir <- fs::path(get_slf_dir(), "IT_extracts")

--- a/R/get_ltcs_path.R
+++ b/R/get_ltcs_path.R
@@ -1,12 +1,12 @@
 #' Get the full path to the SLF deaths lookup file
 #'
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #' @param year financial year e.g. "1920"
 #'
 #' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_ltcs_path <- function(year, ...) {
   ltcs_file_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "LTCs"),

--- a/R/get_ltcs_path.R
+++ b/R/get_ltcs_path.R
@@ -3,7 +3,7 @@
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #' @param year financial year e.g. "1920"
 #'
-#' @return The path to the costs lookup as an \code{\link[fs]{path}}
+#' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_nsu_paths.R
+++ b/R/get_nsu_paths.R
@@ -3,7 +3,7 @@
 #' @param year Year of extract
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the NSU file as an \code{\link[fs]{path}}
+#' @return The path to the NSU file as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_nsu_paths.R
+++ b/R/get_nsu_paths.R
@@ -1,12 +1,12 @@
 #' Get the NSU file path for the given year
 #'
 #' @param year Year of extract
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the NSU file as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_nsu_path <- function(year, ...) {
   nsu_file_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "NSU"),

--- a/R/get_practice_details_path.R
+++ b/R/get_practice_details_path.R
@@ -1,12 +1,12 @@
 #' Get the path to the Practice Details file
 #'
-#' @param update the update month (defaults to use \code{\link{latest_update}})
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param update the update month (defaults to use [latest_update()])
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the Practice Details file as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_practice_details_path <- function(update = latest_update(), ...) {
   practice_details_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "Lookups"),

--- a/R/get_practice_details_path.R
+++ b/R/get_practice_details_path.R
@@ -3,7 +3,7 @@
 #' @param update the update month (defaults to use \code{\link{latest_update}})
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the Practice Details file as an \code{\link[fs]{path}}
+#' @return The path to the Practice Details file as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_sc_ch_episodes_path.R
+++ b/R/get_sc_ch_episodes_path.R
@@ -1,14 +1,14 @@
 #' Get the Care Home all episodes file path
 #'
 #' @param update The update month to use,
-#' defaults to \code{\link{latest_update}}
+#' defaults to [latest_update()]
 #'
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the care home episodes file as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_sc_ch_episodes_path <- function(update = latest_update(), ...) {
   sc_ch_episodes_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "Social_care"),

--- a/R/get_sc_ch_episodes_path.R
+++ b/R/get_sc_ch_episodes_path.R
@@ -5,7 +5,7 @@
 #'
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the care home episodes file as an \code{\link[fs]{path}}
+#' @return The path to the care home episodes file as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_sc_demog_path.R
+++ b/R/get_sc_demog_path.R
@@ -1,15 +1,15 @@
 #' Get the Social Care Demographic lookup file path
 #'
 #' @param update The update month to use,
-#' defaults to \code{\link{latest_update}}
+#' defaults to [latest_update()]
 #'
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the social care demographic file
 #' as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_sc_demog_lookup_path <- function(update = latest_update(), ...) {
   sc_demog_lookup_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "Social_care"),

--- a/R/get_sc_demog_path.R
+++ b/R/get_sc_demog_path.R
@@ -6,7 +6,7 @@
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
 #' @return The path to the social care demographic file
-#' as an \code{\link[fs]{path}}
+#' as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_slf_lookup_paths.R
+++ b/R/get_slf_lookup_paths.R
@@ -3,7 +3,7 @@
 #' @param update the update month (defaults to use \code{\link{latest_update}})
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the SLF Postcode lookup as an \code{\link[fs]{path}}
+#' @return The path to the SLF Postcode lookup as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.
@@ -20,7 +20,7 @@ get_slf_postcode_path <- function(update = latest_update(), ...) {
 #' @param update the update month (defaults to use \code{\link{latest_update}})
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the SLF GP practice lookup as an \code{\link[fs]{path}}
+#' @return The path to the SLF GP practice lookup as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.
@@ -38,7 +38,7 @@ get_slf_gpprac_path <- function(update = latest_update(), ...) {
 #' defaults to \code{\link{latest_update}}
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the costs lookup as an \code{\link[fs]{path}}
+#' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_slf_lookup_paths.R
+++ b/R/get_slf_lookup_paths.R
@@ -1,12 +1,12 @@
 #' Get the full path to the SLF Postcode lookup
 #'
-#' @param update the update month (defaults to use \code{\link{latest_update}})
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param update the update month (defaults to use [latest_update()])
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the SLF Postcode lookup as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_slf_postcode_path <- function(update = latest_update(), ...) {
   get_file_path(
     directory = fs::path(get_slf_dir(), "Lookups"),
@@ -17,13 +17,13 @@ get_slf_postcode_path <- function(update = latest_update(), ...) {
 
 #' Get the full path to the SLF GP practice lookup
 #'
-#' @param update the update month (defaults to use \code{\link{latest_update}})
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param update the update month (defaults to use [latest_update()])
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the SLF GP practice lookup as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_slf_gpprac_path <- function(update = latest_update(), ...) {
   get_file_path(
     directory = fs::path(get_slf_dir(), "Lookups"),
@@ -35,13 +35,13 @@ get_slf_gpprac_path <- function(update = latest_update(), ...) {
 #' Get the full path to the SLF deaths lookup file
 #'
 #' @param update The update month to use,
-#' defaults to \code{\link{latest_update}}
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' defaults to [latest_update()]
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the costs lookup as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_slf_deaths_path <- function(update = latest_update(), ...) {
   slf_deaths_file_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "Deaths"),

--- a/R/get_source_extract_path.R
+++ b/R/get_source_extract_path.R
@@ -1,7 +1,7 @@
 #' Get Source Extract path
 #'
 #' @param year Year of extract
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #' @param type Name of clean source extract
 #'
 #' @return Path to clean source extract containing data for each dataset

--- a/R/get_sparra_hhg_paths.R
+++ b/R/get_sparra_hhg_paths.R
@@ -4,7 +4,7 @@
 #' @param year Year of extract
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the HHG extract as an \code{\link[fs]{path}}
+#' @return The path to the HHG extract as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.
@@ -23,7 +23,7 @@ get_hhg_path <- function(year, ...) {
 #' @param year Year of extract
 #' @param ... additional arguments passed to \code{\link{get_file_path}}
 #'
-#' @return The path to the SPARRA extract as an \code{\link[fs]{path}}
+#' @return The path to the SPARRA extract as an [fs::path()]
 #' @export
 #' @family file path functions
 #' @seealso \code{\link{get_file_path}} for the generic function.

--- a/R/get_sparra_hhg_paths.R
+++ b/R/get_sparra_hhg_paths.R
@@ -2,12 +2,12 @@
 #' Get the path to the HHG extract
 #'
 #' @param year Year of extract
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the HHG extract as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_hhg_path <- function(year, ...) {
   hhg_file_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "HHG"),
@@ -21,12 +21,12 @@ get_hhg_path <- function(year, ...) {
 #' Get the path to the SPARRA extract
 #'
 #' @param year Year of extract
-#' @param ... additional arguments passed to \code{\link{get_file_path}}
+#' @param ... additional arguments passed to [get_file_path()]
 #'
 #' @return The path to the SPARRA extract as an [fs::path()]
 #' @export
 #' @family file path functions
-#' @seealso \code{\link{get_file_path}} for the generic function.
+#' @seealso [get_file_path()] for the generic function.
 get_sparra_path <- function(year, ...) {
   sparra_file_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "SPARRA"),

--- a/R/produce_sc_ch_episodes_tests.R
+++ b/R/produce_sc_ch_episodes_tests.R
@@ -1,7 +1,7 @@
 #' Produce the Care Home all episodes tests
 #'
 #' @param data new or old data for testing summary flags
-#' (data is from \code{\link{get_sc_ch_episodes_path}})
+#' (data is from [get_sc_ch_episodes_path()])
 #'
 #' @return a dataframe with a count of each flag.
 #'

--- a/R/produce_sc_demog_lookup_tests.R
+++ b/R/produce_sc_demog_lookup_tests.R
@@ -1,7 +1,7 @@
 #' Produce the Social Care Demographic Lookup tests
 #'
 #' @param data new or old data for testing summary flags
-#' (data is from \code{\link{get_sc_demog_lookup_path}})
+#' (data is from [get_sc_demog_lookup_path()])
 #'
 #' @return a dataframe with a count of each flag.
 #'

--- a/R/produce_slf_deaths_tests.R
+++ b/R/produce_slf_deaths_tests.R
@@ -1,10 +1,10 @@
 #' Produce the SLF deaths lookup tests
 #'
 #' @param data new or old data for testing summary
-#' flags (data is from \code{\link{get_slf_deaths_path}})
+#' flags (data is from [get_slf_deaths_path()])
 #
 #' @return a dataframe with a count of each flag
-#' from \code{\link{calculate_measures}}
+#' from [calculate_measures()]
 #' @export
 #' @family produce tests functions
 produce_slf_deaths_tests <- function(data) {

--- a/R/produce_slf_gpprac_tests.R
+++ b/R/produce_slf_gpprac_tests.R
@@ -1,14 +1,14 @@
 #' Produce the GP Practice Lookup tests
 #'
 #' @param data new or old data for testing summary flags
-#' (data is from \code{\link{get_slf_gpprac_path}})
+#' (data is from [get_slf_gpprac_path()])
 #'
 #' @return a dataframe with a count of each flag
-#' from \code{\link{calculate_measures}}
+#' from [calculate_measures()]
 #' @export
 #' @family produce tests functions
-#' @seealso \code{\link{create_hb_test_flags}} and
-#' \code{\link{create_hscp_test_flags}} for creating test flags
+#' @seealso [create_hb_test_flags()] and
+#' [create_hscp_test_flags()] for creating test flags
 produce_slf_gpprac_tests <- function(data) {
   data %>%
     # use functions to create HB and partnership flags

--- a/R/produce_slf_postcode_tests.R
+++ b/R/produce_slf_postcode_tests.R
@@ -1,14 +1,14 @@
 #' Produce the Postcode Lookup tests
 #'
 #' @param data new or old data for testing summary flags
-#' (data is from \code{\link{get_slf_postcode_path}})
+#' (data is from [get_slf_postcode_path()])
 #'
 #' @return a dataframe with a count of each flag
-#' from \code{\link{calculate_measures}}
+#' from [calculate_measures()]
 #' @export
 #' @family produce tests functions
-#' @seealso \code{\link{create_hb_test_flags}} and
-#' \code{\link{create_hscp_test_flags}} for creating test flags
+#' @seealso [create_hb_test_flags()] and
+#' [create_hscp_test_flags()] for creating test flags
 produce_slf_postcode_tests <- function(data) {
   data %>%
     # use functions to create HB and partnership flags

--- a/R/produce_source_acute_tests.R
+++ b/R/produce_source_acute_tests.R
@@ -10,15 +10,15 @@
 #' episode date variables.
 #'
 #' @param data new or old data for testing summary flags
-#' (data is from \code{\link{get_source_extract_path}})
+#' (data is from [get_source_extract_path()])
 #'
 #' @return a dataframe with a count of each flag
-#' from \code{\link{calculate_measures}}
+#' from [calculate_measures()]
 #' @export
 #'
 #' @family produce tests functions
-#' @seealso \code{\link{create_hb_test_flags}},
-#' \code{\link{create_hscp_test_flags}} and \code{\link{create_hb_cost_test_flags}}
+#' @seealso [create_hb_test_flags()],
+#' [create_hscp_test_flags()] and [create_hb_cost_test_flags()]
 #' for creating test flags
 produce_source_extract_tests <- function(data) {
   test_flags <- data %>%

--- a/R/write_tests_xlsx.R
+++ b/R/write_tests_xlsx.R
@@ -1,6 +1,6 @@
 #' Write tests as an xlsx workbook
 #'
-#' @param comparison_data produced by \code{\link{produce_test_comparison}}
+#' @param comparison_data produced by [produce_test_comparison()]
 #' @param sheet_name the name of the dataset - this will be used as the sheet name
 #'
 #' @return source_tests_path to the xlsx file location


### PR DESCRIPTION
I noticed that we were using the old / long-form syntax to create links in the documentation, e.g. `\code{\link[fs]{dir_info}}` whereas the more modern way ([as of Roxygen 6.0.0](https://roxygen2.r-lib.org/articles/markdown.html)) is to use markdown. We can use markdown generally to format the documentation e.g. headings, bullet lists etc. but here I've just replaced the links with `[fs::dir_info()]` etc.

This shouldn't change anything user-facing but will make the documentation a bit cleaner for us to read/write!