### PR TITLE
Fix - duplicate rows being created in HC costs

### DIFF
--- a/All_years/03-Costs/Costs-04-home_care.R
+++ b/All_years/03-Costs/Costs-04-home_care.R
@@ -49,7 +49,8 @@ hc_costs_raw <- readxl::read_xlsx(fs::path(costs_dir, "hc_costs.xlsx")) %>%
 hc_costs <- hc_costs_raw %>%
   left_join(phsopendata::get_resource("967937c4-8d67-4f39-974f-fd58c4acfda5",
     col_select = c("CA", "CAName", "HBName")
-  ),
+  ) %>%
+    distinct(),
   by = c("gss_code" = "CA")
   ) %>%
   select(ca_name = CAName, health_board = HBName, starts_with("sw1_")) %>%


### PR DESCRIPTION
This was the issue which was causing the apparent doubling of hours for some LAs. We were getting duplicates for the CA names, which meant we had some duplicate rows in the costs and then when the costs were matched on duplicate episodes for all of the affected LAs.