### PR TITLE
Fix some build errors/warnings.

### DIFF
--- a/R/get_existing_data_for_tests.R
+++ b/R/get_existing_data_for_tests.R
@@ -21,11 +21,11 @@ get_existing_data_for_tests <- function(new_data) {
 
   variable_names <- c("anon_chi", dplyr::intersect(slfhelper::ep_file_vars, names(new_data)))
 
-  slf_data <- slfhelper::read_slf_episode(
+  slf_data <- suppressWarnings(slfhelper::read_slf_episode(
     year = year,
     recids = recids,
     columns = variable_names
-  ) %>%
+  )) %>%
     dplyr::rename(chi = .data$anon_chi)
 
   return(slf_data)

--- a/tests/testthat/test-get_practice_details_path.R
+++ b/tests/testthat/test-get_practice_details_path.R
@@ -1,4 +1,8 @@
 test_that("GP clusters file (Practice Details) path works", {
   expect_s3_class(get_practice_details_path(ext = "zsav"), "fs_path")
-  expect_error(get_practice_details_path(ext = "rds"))
+  expect_s3_class(get_practice_details_path(), "fs_path")
+
+  expect_equal(fs::path_ext(get_practice_details_path()), "rds")
+
+  expect_match(get_practice_details_path(), glue::glue("practice_details_{latest_update()}"))
 })


### PR DESCRIPTION
The `surpressWarnings` is needed as `{slfhelper}` loads `{fst}` which produces the warning:
```
fst package v0.9.8
Warning message:
package ‘fst’ was built under R version 3.6.3
```
I could/should probably suppress this more cleverly in slfhelper itself!

The `get_practice_details` test failure is just because we now also produce an rds version. These errors will become more common as we make rds versions and eventually stop producing zsav versions, so we just need to stay on top of them.