### PR TITLE
include permission fix 

### DIFF
--- a/R/write_tests_xlsx.R
+++ b/R/write_tests_xlsx.R
@@ -33,5 +33,7 @@ write_tests_xlsx <- function(comparison_data, sheet_name) {
     overwrite = TRUE
   )
 
+  fs::file_chmod(path = source_tests_path, mode = "660")
+
   return(source_tests_path)
 }


### PR DESCRIPTION
This should stop the problem of permissions changing for the group to read only. This is the same code in `write_sav` and `write_rds` functions