### PR TITLE
Remove unnecessary code

### DIFF
--- a/R/calculate_measures.R
+++ b/R/calculate_measures.R
@@ -28,8 +28,7 @@ calculate_measures <- function(data, vars = NULL, measure = c("sum", "all", "min
       dplyr::summarise(
         dplyr::across(tidyselect::everything(), ~ min(.x, na.rm = TRUE), .names = "min_{col}"),
         dplyr::across(tidyselect::everything(vars = !tidyselect::starts_with("min_")), ~ max(.x, na.rm = TRUE), .names = "max_{col}")
-      ) %>%
-      dplyr::mutate(dplyr::across(tidyselect::everything(), ~ as.numeric(.x)))
+      )
   }
 
   pivot_data <- data %>%


### PR DESCRIPTION
Quick one - spotted a bug in the tests which was preventing the max and min dates being calculated. This was converting the variables to numeric and not producing the correct format. This was then saying the 'new' data has dropped by 100% when this was not the case.