### PR TITLE
Deal with gender when we have no CHI number.

### DIFF
--- a/2014-15/D01 Make Individual File.sps
+++ b/2014-15/D01 Make Individual File.sps
@@ -575,15 +575,19 @@ save outfile = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav"
     /zcompressed.
 get file = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav".
 
-* Clean up the gender, use the most common (by rounding the mean), if the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI).
+* Clean up the gender, use the most common (by rounding the mean).
+* If the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI.
+* If the person doesn't have a CHI number then set it to 9 (not recorded / not specified)
 Do if gender NE 1.5.
     Compute gender = rnd(gender).
-Else.
+Else if gender = 1.5 AND chi NE "".
     Do if Mod(number(char.substr(chi, 9, 1), F1.0), 2) = 1.
         Compute gender = 1.
     Else.
         Compute gender = 2.
     End If.
+Else if gender = 1.5 AND chi = "".
+	Compute gender = 9.
 End If.
 
 Alter type gender (F1.0).

--- a/2015-16/D01 Make Individual File.sps
+++ b/2015-16/D01 Make Individual File.sps
@@ -575,15 +575,19 @@ save outfile = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav"
     /zcompressed.
 get file = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav".
 
-* Clean up the gender, use the most common (by rounding the mean), if the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI).
+* Clean up the gender, use the most common (by rounding the mean).
+* If the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI.
+* If the person doesn't have a CHI number then set it to 9 (not recorded / not specified)
 Do if gender NE 1.5.
     Compute gender = rnd(gender).
-Else.
+Else if gender = 1.5 AND chi NE "".
     Do if Mod(number(char.substr(chi, 9, 1), F1.0), 2) = 1.
         Compute gender = 1.
     Else.
         Compute gender = 2.
     End If.
+Else if gender = 1.5 AND chi = "".
+	Compute gender = 9.
 End If.
 
 Alter type gender (F1.0).

--- a/2016-17/D01 Make Individual File.sps
+++ b/2016-17/D01 Make Individual File.sps
@@ -575,15 +575,19 @@ save outfile = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav"
     /zcompressed.
 get file = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav".
 
-* Clean up the gender, use the most common (by rounding the mean), if the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI).
+* Clean up the gender, use the most common (by rounding the mean).
+* If the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI.
+* If the person doesn't have a CHI number then set it to 9 (not recorded / not specified)
 Do if gender NE 1.5.
     Compute gender = rnd(gender).
-Else.
+Else if gender = 1.5 AND chi NE "".
     Do if Mod(number(char.substr(chi, 9, 1), F1.0), 2) = 1.
         Compute gender = 1.
     Else.
         Compute gender = 2.
     End If.
+Else if gender = 1.5 AND chi = "".
+	Compute gender = 9.
 End If.
 
 Alter type gender (F1.0).

--- a/2017-18/D01 Make Individual File.sps
+++ b/2017-18/D01 Make Individual File.sps
@@ -575,15 +575,19 @@ save outfile = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav"
     /zcompressed.
 get file = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav".
 
-* Clean up the gender, use the most common (by rounding the mean), if the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI).
+* Clean up the gender, use the most common (by rounding the mean).
+* If the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI.
+* If the person doesn't have a CHI number then set it to 9 (not recorded / not specified)
 Do if gender NE 1.5.
     Compute gender = rnd(gender).
-Else.
+Else if gender = 1.5 AND chi NE "".
     Do if Mod(number(char.substr(chi, 9, 1), F1.0), 2) = 1.
         Compute gender = 1.
     Else.
         Compute gender = 2.
     End If.
+Else if gender = 1.5 AND chi = "".
+	Compute gender = 9.
 End If.
 
 Alter type gender (F1.0).

--- a/2018-19/D01 Make Individual File.sps
+++ b/2018-19/D01 Make Individual File.sps
@@ -575,15 +575,19 @@ save outfile = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav"
     /zcompressed.
 get file = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav".
 
-* Clean up the gender, use the most common (by rounding the mean), if the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI).
+* Clean up the gender, use the most common (by rounding the mean).
+* If the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI.
+* If the person doesn't have a CHI number then set it to 9 (not recorded / not specified)
 Do if gender NE 1.5.
     Compute gender = rnd(gender).
-Else.
+Else if gender = 1.5 AND chi NE "".
     Do if Mod(number(char.substr(chi, 9, 1), F1.0), 2) = 1.
         Compute gender = 1.
     Else.
         Compute gender = 2.
     End If.
+Else if gender = 1.5 AND chi = "".
+	Compute gender = 9.
 End If.
 
 Alter type gender (F1.0).

--- a/2019-20/D01 Make Individual File.sps
+++ b/2019-20/D01 Make Individual File.sps
@@ -575,15 +575,19 @@ save outfile = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav"
     /zcompressed.
 get file = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav".
 
-* Clean up the gender, use the most common (by rounding the mean), if the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI).
+* Clean up the gender, use the most common (by rounding the mean).
+* If the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI.
+* If the person doesn't have a CHI number then set it to 9 (not recorded / not specified)
 Do if gender NE 1.5.
     Compute gender = rnd(gender).
-Else.
+Else if gender = 1.5 AND chi NE "".
     Do if Mod(number(char.substr(chi, 9, 1), F1.0), 2) = 1.
         Compute gender = 1.
     Else.
         Compute gender = 2.
     End If.
+Else if gender = 1.5 AND chi = "".
+	Compute gender = 9.
 End If.
 
 Alter type gender (F1.0).

--- a/2020-21/D01 Make Individual File.sps
+++ b/2020-21/D01 Make Individual File.sps
@@ -575,15 +575,19 @@ save outfile = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav"
     /zcompressed.
 get file = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav".
 
-* Clean up the gender, use the most common (by rounding the mean), if the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI).
+* Clean up the gender, use the most common (by rounding the mean).
+* If the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI.
+* If the person doesn't have a CHI number then set it to 9 (not recorded / not specified)
 Do if gender NE 1.5.
     Compute gender = rnd(gender).
-Else.
+Else if gender = 1.5 AND chi NE "".
     Do if Mod(number(char.substr(chi, 9, 1), F1.0), 2) = 1.
         Compute gender = 1.
     Else.
         Compute gender = 2.
     End If.
+Else if gender = 1.5 AND chi = "".
+	Compute gender = 9.
 End If.
 
 Alter type gender (F1.0).

--- a/2021-22/D01 Make Individual File.sps
+++ b/2021-22/D01 Make Individual File.sps
@@ -575,15 +575,19 @@ save outfile = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav"
     /zcompressed.
 get file = !Year_dir + "temp-source-individual-file-1-20" + !FY + ".zsav".
 
-* Clean up the gender, use the most common (by rounding the mean), if the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI).
+* Clean up the gender, use the most common (by rounding the mean).
+* If the mean is 1.5 (i.e. no gender known or equal male and females) then take it from the CHI.
+* If the person doesn't have a CHI number then set it to 9 (not recorded / not specified)
 Do if gender NE 1.5.
     Compute gender = rnd(gender).
-Else.
+Else if gender = 1.5 AND chi NE "".
     Do if Mod(number(char.substr(chi, 9, 1), F1.0), 2) = 1.
         Compute gender = 1.
     Else.
         Compute gender = 2.
     End If.
+Else if gender = 1.5 AND chi = "".
+	Compute gender = 9.
 End If.
 
 Alter type gender (F1.0).


### PR DESCRIPTION
Fixes #276 

There is a very small chance that we have someone who was legitimately coded with `0` who we now switch to `9`. We'd need a more substantial change to identify people where **all** of their codes were `0` before the aggregate, then we could retrieve this later.

See the data dictionary for definitions: [https://www.ndc.scot.nhs.uk/Dictionary-A-Z/Definitions/index.asp?Search=S&ID=1277&Title=Sex]()