### PR TITLE
Fix write tests function

### DIFF
--- a/R/write_tests_xlsx.R
+++ b/R/write_tests_xlsx.R
@@ -15,30 +15,34 @@ write_tests_xlsx <- function(comparison_data, sheet_name) {
   source_tests_path <- fs::path(get_slf_dir(), "Tests", glue::glue(latest_update(), "_tests.xlsx"))
 
   if (fs::file_exists(source_tests_path)) {
-    # Load excel workbook
+    # Load the data from the existing workbook
     wb <- openxlsx::loadWorkbook(source_tests_path)
   } else {
-    # create excelworkbook
+    # Create a blank workbook object
     wb <- openxlsx::createWorkbook()
+
+    # Create a dummy file
+    fs::file_touch(path = source_tests_path)
+    # Set the correct permissions
+    fs::file_chmod(path = source_tests_path, mode = "660")
   }
 
-  sheet_name_dated <- paste0(sheet_name, "-", format(Sys.Date(), "%d %b"))
-
   # add a new sheet for tests
+  sheet_name_dated <- paste0(sheet_name, "-", format(Sys.Date(), "%d %b"))
   openxlsx::addWorksheet(wb, sheet_name_dated)
-  # write comparison output to new sheet
+
+  # write test comparison output to the new sheet
   openxlsx::writeData(
     wb,
     sheet_name_dated,
     comparison_data
   )
-  # save output
+
+  # Write the data to the workbook on disk
   openxlsx::saveWorkbook(wb,
     source_tests_path,
     overwrite = TRUE
   )
-
-  fs::file_chmod(path = source_tests_path, mode = "660")
 
   return(source_tests_path)
 }

--- a/R/write_tests_xlsx.R
+++ b/R/write_tests_xlsx.R
@@ -1,18 +1,25 @@
 #' Write out Tests
 #'
-#' @description Write test output as an xlsx workbook, specific sheet for each extract
+#' @description Write test output as an xlsx workbook, with a specific sheet
+#' for each extract. The extract sheet will be dated with the current month and
+#' day, which allows us to run the tests multiple times in the same update.
 #'
 #' @param comparison_data produced by [produce_test_comparison()]
-#' @param sheet_name the name of the dataset - this will be used as the sheet name
+#' @param sheet_name the name of the dataset, which will be used to create
+#' the sheet name
 #'
-#' @return source_tests_path to the xlsx file location
+#' @return the path to the xlsx file location
 #'
 #' @export
 #'
 #' @family test functions
 #' @seealso produce_test_comparison
 write_tests_xlsx <- function(comparison_data, sheet_name) {
-  source_tests_path <- fs::path(get_slf_dir(), "Tests", glue::glue(latest_update(), "_tests.xlsx"))
+  source_tests_path <- fs::path(
+    get_slf_dir(),
+    "Tests",
+    glue::glue(latest_update(), "_tests.xlsx")
+  )
 
   if (fs::file_exists(source_tests_path)) {
     # Load the data from the existing workbook

--- a/man/write_tests_xlsx.Rd
+++ b/man/write_tests_xlsx.Rd
@@ -9,13 +9,16 @@ write_tests_xlsx(comparison_data, sheet_name)
 \arguments{
 \item{comparison_data}{produced by \code{\link[=produce_test_comparison]{produce_test_comparison()}}}
 
-\item{sheet_name}{the name of the dataset - this will be used as the sheet name}
+\item{sheet_name}{the name of the dataset, which will be used to create
+the sheet name}
 }
 \value{
-source_tests_path to the xlsx file location
+the path to the xlsx file location
 }
 \description{
-Write test output as an xlsx workbook, specific sheet for each extract
+Write test output as an xlsx workbook, with a specific sheet
+for each extract. The extract sheet will be dated with the current month and
+day, which allows us to run the tests multiple times in the same update.
 }
 \seealso{
 produce_test_comparison


### PR DESCRIPTION
Fixes #288 

The main change is to only try and change the permissions when creating the file for the first time (i.e. if it doesn't already exist). Other minor changes are to improve comments and documentation.