### PR TITLE
Bug fix - cost variables should be '_cost' not '_costs'

### DIFF
--- a/R/create_monthly_costs.R
+++ b/R/create_monthly_costs.R
@@ -16,10 +16,10 @@
 create_monthly_costs <- function(data, yearstay = yearstay, cost_total_net = cost_total_net) {
   costs <- data %>%
     dplyr::select(dplyr::ends_with("_beddays")) %>%
-    dplyr::rename_with(~ stringr::str_replace(., "_beddays", "_costs"))
+    dplyr::rename_with(~ stringr::str_replace(., "_beddays", "_cost"))
 
   data <- dplyr::bind_cols(data, costs) %>%
-    dplyr::mutate(dplyr::across(dplyr::ends_with("_costs"), ~ dplyr::if_else(.x != 0, .x / {{ yearstay }} * {{ cost_total_net }}, 0)))
+    dplyr::mutate(dplyr::across(dplyr::ends_with("_cost"), ~ dplyr::if_else(.x != 0, .x / {{ yearstay }} * {{ cost_total_net }}, 0)))
 
   return(data)
 }


### PR DESCRIPTION
Fix a bug / typo where the new cost variables being created are named as '_costs' (with an s) whereas they should be just '_cost'.