### PR TITLE
Adding an action to do R CMD Check on GitHub

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@
 ^Make_R_files$
 ^Production_scripts$
 ^R_development_SOP\.md$
+^codecov\.yml$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,45 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main-R]
+  pull_request:
+    branches: [main-R]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: '3.6'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,31 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main-R]
+  pull_request:
+    branches: [main-R]
+
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr
+          needs: coverage
+
+      - name: Test coverage
+        run: covr::codecov(quiet = FALSE)
+        shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     tidyr (>= 1.2.0),
     tidyselect (>= 1.1.2),
 Suggests:
+    covr,
     roxygen2,
     spelling (>= 2.2),
     testthat (>= 3.1.4)

--- a/R/find_latest_file.R
+++ b/R/find_latest_file.R
@@ -15,9 +15,11 @@
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' find_latest_file(get_lookups_dir(),
 #'   regexp = "Scottish_Postcode_Directory_.+?\\.rds"
 #' )
+#' }
 find_latest_file <- function(dir, ..., recurse = TRUE) {
   fs::dir_info(path = dir, type = "file", ..., recurse = recurse) %>%
     dplyr::arrange(dplyr::desc(.data$birth_time), dplyr::desc(.data$modification_time)) %>%

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+  <!-- badges: start -->
+  [![R-CMD-check](https://github.com/Public-Health-Scotland/source-linkage-files/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Public-Health-Scotland/source-linkage-files/actions/workflows/R-CMD-check.yaml)
+  <!-- badges: end -->
 # source-linkage-files
 This repo is for the SPSS syntax used for the PHS Source Linkage File (SLF) project. 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
   <!-- badges: start -->
   [![R-CMD-check](https://github.com/Public-Health-Scotland/source-linkage-files/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Public-Health-Scotland/source-linkage-files/actions/workflows/R-CMD-check.yaml)
+  [![Codecov test coverage](https://codecov.io/gh/Public-Health-Scotland/source-linkage-files/branch/master/graph/badge.svg)](https://app.codecov.io/gh/Public-Health-Scotland/source-linkage-files?branch=master)
   <!-- badges: end -->
+
 # source-linkage-files
 This repo is for the SPSS syntax used for the PHS Source Linkage File (SLF) project. 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/man/find_latest_file.Rd
+++ b/man/find_latest_file.Rd
@@ -24,7 +24,9 @@ find the files then picks the one with the latest
 \code{birthtime}
 }
 \examples{
+\dontrun{
 find_latest_file(get_lookups_dir(),
   regexp = "Scottish_Postcode_Directory_.+?\\\\.rds"
 )
+}
 }

--- a/tests/testthat/test-check_char_is_missing.R
+++ b/tests/testthat/test-check_char_is_missing.R
@@ -6,7 +6,16 @@ test_that("is_missing works", {
   expect_equal(is_missing(c("a", NA, "c")), c(FALSE, TRUE, FALSE))
   expect_equal(is_missing(c(NA, NA, "")), c(TRUE, TRUE, TRUE))
 
-  expect_error(is_missing(c(1, 2, 3)), ", but numeric was supplied")
-  expect_error(is_missing(c(TRUE, FALSE)), ", but logical was supplied")
-  expect_error(is_missing(as.Date(c("2020-01-01", "1990-09-01"))), ", but Date was supplied")
+  expect_error(
+    is_missing(c(1, 2, 3)),
+    ", but numeric was supplied"
+  )
+  expect_error(
+    is_missing(c(TRUE, FALSE)),
+    ", but logical was supplied"
+  )
+  expect_error(
+    is_missing(as.Date(c("2020-01-01", "1990-09-01"))),
+    ", but Date was supplied"
+  )
 })

--- a/tests/testthat/test-check_year_format.R
+++ b/tests/testthat/test-check_year_format.R
@@ -5,7 +5,10 @@ test_that("Check year format works", {
   expect_equal(check_year_format("2017", format = "alternate"), "2017")
 
   # Vector of years
-  expect_equal(check_year_format(c("1718", "1819", "1920")), c("1718", "1819", "1920"))
+  expect_equal(
+    check_year_format(c("1718", "1819", "1920")),
+    c("1718", "1819", "1920")
+  )
   expect_equal(
     check_year_format(c("2017", "2018", "2019"), format = "alternate"),
     c("2017", "2018", "2019")
@@ -20,7 +23,10 @@ test_that("Check year format works", {
     expect_message("`year` will be converted to a character")
 
   # Vectors
-  expect_equal(check_year_format(c(1718, 1819, 1920)), c("1718", "1819", "1920")) %>%
+  expect_equal(
+    check_year_format(c(1718, 1819, 1920)),
+    c("1718", "1819", "1920")
+  ) %>%
     expect_message("`year` will be converted to a character")
   expect_equal(
     check_year_format(c(2017, 2018, 2019), format = "alternate"),

--- a/tests/testthat/test-create_monthly_beddays.R
+++ b/tests/testthat/test-create_monthly_beddays.R
@@ -16,6 +16,10 @@ test_that("monthly beddays work", {
     ))
   )
 
-  expect_snapshot(as.data.frame(create_monthly_beddays(input_data, year = "1920", adm_date, dis_date)))
-  expect_snapshot(as.data.frame(create_monthly_beddays(input_data, year = "2021", adm_date, dis_date)))
+  expect_snapshot(as.data.frame(
+    create_monthly_beddays(input_data, year = "1920", adm_date, dis_date)
+  ))
+  expect_snapshot(as.data.frame(
+    create_monthly_beddays(input_data, year = "2021", adm_date, dis_date)
+  ))
 })

--- a/tests/testthat/test-get_cohorts_paths.R
+++ b/tests/testthat/test-get_cohorts_paths.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("Cohorts paths work", {
   expect_s3_class(get_demog_cohorts_path("1920", ext = "zsav"), "fs_path")
   expect_s3_class(get_service_use_cohorts_path("1920", ext = "zsav"), "fs_path")

--- a/tests/testthat/test-get_costs_paths.R
+++ b/tests/testthat/test-get_costs_paths.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("Costs paths work", {
   expect_s3_class(get_ch_costs_path(ext = "sav"), "fs_path")
   expect_s3_class(get_dn_costs_path(ext = "sav"), "fs_path")

--- a/tests/testthat/test-get_dd_path.R
+++ b/tests/testthat/test-get_dd_path.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("Delayed discharges path works", {
   expect_s3_class(get_dd_path(ext = "zsav"), "fs_path")
   expect_error(

--- a/tests/testthat/test-get_existing_data_for_tests.R
+++ b/tests/testthat/test-get_existing_data_for_tests.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("Get existing data works", {
   dummy_new_data <- tibble(
     year = "1920",

--- a/tests/testthat/test-get_file_paths.R
+++ b/tests/testthat/test-get_file_paths.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("main SLF directory exists", {
   slf_dir_path <- get_slf_dir()
 
@@ -10,11 +12,29 @@ test_that("get_year_dir works", {
   # Base dir must exist
   expect_true(fs::dir_exists("/conf/sourcedev/Source_Linkage_File_Updates"))
 
-  expect_equal(get_year_dir("1112"), fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "1112"))
-  expect_equal(get_year_dir("1920"), fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "1920"))
-  expect_equal(get_year_dir("2122"), fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "2122"))
+  expect_equal(
+    get_year_dir("1112"),
+    fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "1112")
+  )
+  expect_equal(
+    get_year_dir("1920"),
+    fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "1920")
+  )
+  expect_equal(
+    get_year_dir("2122"),
+    fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "2122")
+  )
 
-  expect_equal(get_year_dir("1112", extracts_dir = TRUE), fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "1112", "Extracts"))
-  expect_equal(get_year_dir("1920", extracts_dir = TRUE), fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "1920", "Extracts"))
-  expect_equal(get_year_dir("2122", extracts_dir = TRUE), fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "2122", "Extracts"))
+  expect_equal(
+    get_year_dir("1112", extracts_dir = TRUE),
+    fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "1112", "Extracts")
+  )
+  expect_equal(
+    get_year_dir("1920", extracts_dir = TRUE),
+    fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "1920", "Extracts")
+  )
+  expect_equal(
+    get_year_dir("2122", extracts_dir = TRUE),
+    fs::path("/conf/sourcedev/Source_Linkage_File_Updates", "2122", "Extracts")
+  )
 })

--- a/tests/testthat/test-get_it_extract_paths.R
+++ b/tests/testthat/test-get_it_extract_paths.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("IT extract file paths work", {
   expect_s3_class(get_it_ltc_path(), "fs_path")
   expect_s3_class(get_it_deaths_path(), "fs_path")

--- a/tests/testthat/test-get_nsu_paths.R
+++ b/tests/testthat/test-get_nsu_paths.R
@@ -1,3 +1,4 @@
+skip_on_ci()
 
 test_that("NSU file path works", {
   expect_s3_class(get_nsu_path(year = "1920", ext = "zsav"), "fs_path")

--- a/tests/testthat/test-get_practice_details_path.R
+++ b/tests/testthat/test-get_practice_details_path.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("GP clusters file (Practice Details) path works", {
   expect_s3_class(get_practice_details_path(ext = "zsav"), "fs_path")
   expect_s3_class(get_practice_details_path(), "fs_path")

--- a/tests/testthat/test-get_sc_ch_episodes_path.R
+++ b/tests/testthat/test-get_sc_ch_episodes_path.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("SC care home episodes file path works", {
   expect_s3_class(get_sc_ch_episodes_path(ext = "zsav"), "fs_path")
   expect_s3_class(get_sc_ch_episodes_path(update = previous_update(), ext = "zsav"), "fs_path")

--- a/tests/testthat/test-get_sc_demog_path.R
+++ b/tests/testthat/test-get_sc_demog_path.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("SC demographic file path works", {
   expect_s3_class(get_sc_demog_lookup_path(ext = "zsav"), "fs_path")
   expect_s3_class(

--- a/tests/testthat/test-get_slf_lookup_paths.R
+++ b/tests/testthat/test-get_slf_lookup_paths.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("SLF postcode lookup file paths work", {
   expect_s3_class(get_slf_postcode_path(ext = "zsav"), "fs_path")
   expect_s3_class(get_slf_postcode_path(update = previous_update(), ext = "zsav"), "fs_path")

--- a/tests/testthat/test-get_sparra_hhg_paths.R
+++ b/tests/testthat/test-get_sparra_hhg_paths.R
@@ -1,3 +1,5 @@
+skip_on_ci()
+
 test_that("HHG file path works", {
   expect_s3_class(get_hhg_path("1920", ext = "zsav"), "fs_path")
 


### PR DESCRIPTION
When tests rely on something internal, not available to GitHub e.g. data files then I have added `skip_on_ci()` to the test files.