### PR TITLE
308 update create monthly beddays

### DIFF
--- a/R/create_monthly_beddays.R
+++ b/R/create_monthly_beddays.R
@@ -22,7 +22,11 @@ create_monthly_beddays <- function(data, year, admission_date, discharge_date, c
   data <- data %>%
     dplyr::mutate(stay_interval = lubridate::interval(
       {{ admission_date }},
-      {{ discharge_date }}
+      # If discharge date is NA then calculate beddays to the end of the year
+      dplyr::if_else(is.na({{ discharge_date }}),
+        end_fy(year) + lubridate::days(1),
+        {{ discharge_date }}
+      )
     ) %>%
       # Shift it forward by a day (default)
       # so we will count the last day and not the first.

--- a/R/create_monthly_beddays.R
+++ b/R/create_monthly_beddays.R
@@ -18,6 +18,37 @@
 #' @seealso create_monthly_costs
 create_monthly_beddays <- function(data, year, admission_date, discharge_date, count_last = TRUE) {
 
+  # Extract date vectors for checking
+  admission_dates_vector <- dplyr::pull(data, {{ admission_date }})
+  discharge_dates_vector <- dplyr::pull(data, {{ discharge_date }})
+
+  # Check that dates are the correct types
+  if (!inherits(admission_dates_vector, c("Date", "POSIXct"))) {
+    cli::cli_abort(c("{.var admission_date} must be a `Date` or `POSIXct` vector",
+      "x" = "You've supplied {?a/an} {.cls {class(admission_dates_vector)}} vector"
+    ))
+  }
+  if (!inherits(discharge_dates_vector, c("Date", "POSIXct"))) {
+    cli::cli_abort(c("{.var discharge_date} must be a `Date` or `POSIXct` vector",
+      "x" = "You've supplied {?a/an} {.cls {class(discharge_dates_vector)}} vector"
+    ))
+  }
+
+  # Check that discharge_date always comes after admission_date (or all discharge_dates_vector is NA)
+  if (any(admission_dates_vector > discharge_dates_vector, na.rm = TRUE) & !all(is.na(discharge_dates_vector))) {
+    first_error <- which.max(admission_dates_vector > discharge_dates_vector)
+
+    cli::cli_abort(c("{.var discharge_date} must not be earlier than
+                       {.var admission_date}",
+      "i" = "See case {first_error} where
+         {.var admission_date} = '{admission_dates_vector[first_error]}' and
+         {.var discharge_date} = '{discharge_dates_vector[first_error]}'",
+      "There {?is/are} {sum(admission_dates_vector > discharge_dates_vector, na.rm = TRUE)}
+        error{?s} in total."
+    ))
+  }
+
+
   # Create a 'stay interval' from the episode dates
   data <- data %>%
     dplyr::mutate(stay_interval = lubridate::interval(

--- a/tests/testthat/_snaps/create_monthly_beddays.md
+++ b/tests/testthat/_snaps/create_monthly_beddays.md
@@ -1,3 +1,9 @@
+# monthly beddays errors properly
+
+    `discharge_date` must not be earlier than `admission_date`
+    i See case 9 where `admission_date` = '2022-01-01' and `discharge_date` = '2020-01-01'
+    There are 2 errors in total.
+
 # monthly beddays work as expected
 
     Code

--- a/tests/testthat/_snaps/create_monthly_beddays.md
+++ b/tests/testthat/_snaps/create_monthly_beddays.md
@@ -1,4 +1,38 @@
-# monthly beddays work
+# monthly beddays work as expected
+
+    Code
+      as.data.frame(create_monthly_beddays(input_data, year = "1819", adm_date,
+        dis_date))
+    Output
+          adm_date   dis_date apr_beddays may_beddays jun_beddays jul_beddays
+      1 2020-01-02 2021-01-01           0           0           0           0
+      2 2020-04-05 2021-02-01           0           0           0           0
+      3 2020-09-20 2020-12-31           0           0           0           0
+      4 2017-01-01 2022-12-01          30          31          30          31
+      5 2021-03-01 2021-03-05           0           0           0           0
+      6 2019-01-01       <NA>           0           0           0           0
+      7 2020-01-01       <NA>           0           0           0           0
+      8 2021-01-01       <NA>           0           0           0           0
+        aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays
+      1           0           0           0           0           0           0
+      2           0           0           0           0           0           0
+      3           0           0           0           0           0           0
+      4          31          30          31          30          31          31
+      5           0           0           0           0           0           0
+      6           0           0           0           0           0          30
+      7           0           0           0           0           0           0
+      8           0           0           0           0           0           0
+        feb_beddays mar_beddays
+      1           0           0
+      2           0           0
+      3           0           0
+      4          28          31
+      5           0           0
+      6          28          31
+      7           0           0
+      8           0           0
+
+---
 
     Code
       as.data.frame(create_monthly_beddays(input_data, year = "1920", adm_date,
@@ -10,18 +44,27 @@
       3 2020-09-20 2020-12-31           0           0           0           0
       4 2017-01-01 2022-12-01          30          31          30          31
       5 2021-03-01 2021-03-05           0           0           0           0
+      6 2019-01-01       <NA>          30          31          30          31
+      7 2020-01-01       <NA>           0           0           0           0
+      8 2021-01-01       <NA>           0           0           0           0
         aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays
       1           0           0           0           0           0          29
       2           0           0           0           0           0           0
       3           0           0           0           0           0           0
       4          31          30          31          30          31          31
       5           0           0           0           0           0           0
+      6          31          30          31          30          31          31
+      7           0           0           0           0           0          30
+      8           0           0           0           0           0           0
         feb_beddays mar_beddays
       1          29          31
       2           0           0
       3           0           0
       4          29          31
       5           0           0
+      6          29          31
+      7          29          31
+      8           0           0
 
 ---
 
@@ -35,16 +78,25 @@
       3 2020-09-20 2020-12-31           0           0           0           0
       4 2017-01-01 2022-12-01          30          31          30          31
       5 2021-03-01 2021-03-05           0           0           0           0
+      6 2019-01-01       <NA>          30          31          30          31
+      7 2020-01-01       <NA>          30          31          30          31
+      8 2021-01-01       <NA>           0           0           0           0
         aug_beddays sep_beddays oct_beddays nov_beddays dec_beddays jan_beddays
       1          31          30          31          30          31           1
       2          31          30          31          30          31          31
       3           0          10          31          30          31           0
       4          31          30          31          30          31          31
       5           0           0           0           0           0           0
+      6          31          30          31          30          31          31
+      7          31          30          31          30          31          31
+      8           0           0           0           0           0          30
         feb_beddays mar_beddays
       1           0           0
       2           1           0
       3           0           0
       4          28          31
       5           0           4
+      6          28          31
+      7          28          31
+      8          28          31
 

--- a/tests/testthat/test-create_monthly_beddays.R
+++ b/tests/testthat/test-create_monthly_beddays.R
@@ -1,21 +1,30 @@
-test_that("monthly beddays work", {
+test_that("monthly beddays work as expected", {
   input_data <- tibble(
     adm_date = as.Date(c(
       "2020-01-02",
       "2020-04-05",
       "2020-09-20",
       "2017-01-01",
-      "2021-03-01"
+      "2021-03-01",
+      "2019-01-01",
+      "2020-01-01",
+      "2021-01-01"
     )),
     dis_date = as.Date(c(
       "2021-01-01",
       "2021-02-01",
       "2020-12-31",
       "2022-12-01",
-      "2021-03-05"
+      "2021-03-05",
+      NA,
+      NA,
+      NA
     ))
   )
 
+  expect_snapshot(as.data.frame(
+    create_monthly_beddays(input_data, year = "1819", adm_date, dis_date)
+  ))
   expect_snapshot(as.data.frame(
     create_monthly_beddays(input_data, year = "1920", adm_date, dis_date)
   ))

--- a/tests/testthat/test-create_monthly_beddays.R
+++ b/tests/testthat/test-create_monthly_beddays.R
@@ -1,3 +1,67 @@
+test_that("monthly beddays errors properly", {
+  expect_error(
+    create_monthly_beddays(
+      tibble(start_date = Sys.Date(), end_date = "2021-01-01"),
+      "2223",
+      start_date,
+      end_date
+    ),
+    "`discharge_date` must be a `Date` or `POSIXct` vector"
+  )
+
+  expect_error(
+    create_monthly_beddays(
+      tibble(start_date = "2021-01-01", end_date = Sys.Date()),
+      "2223",
+      start_date,
+      end_date
+    ),
+    "`admission_date` must be a `Date` or `POSIXct` vector"
+  )
+
+  expect_error(
+    create_monthly_beddays(
+      tibble(start_date = Sys.Date() + 1, end_date = Sys.Date()),
+      "2223",
+      start_date,
+      end_date
+    ),
+    "`discharge_date` must not be earlier than `admission_date`"
+  )
+
+  input_data <- tibble(
+    adm_date = as.Date(c(
+      "2020-01-02",
+      "2020-04-05",
+      "2020-09-20",
+      "2017-01-01",
+      "2021-03-01",
+      "2019-01-01",
+      "2020-01-01",
+      "2021-01-01",
+      "2022-01-01",
+      "2022-04-01"
+    )),
+    dis_date = as.Date(c(
+      "2021-01-01",
+      "2021-02-01",
+      "2020-12-31",
+      "2022-12-01",
+      "2021-03-05",
+      NA,
+      NA,
+      NA,
+      "2020-01-01",
+      "2022-03-31"
+    ))
+  )
+
+  expect_snapshot_error(
+    create_monthly_beddays(input_data, "2122", adm_date, dis_date)
+  )
+})
+
+
 test_that("monthly beddays work as expected", {
   input_data <- tibble(
     adm_date = as.Date(c(


### PR DESCRIPTION
Closes #308 

Expands `create_monthly_beddays` to handle missing (`NA`) values for the discharge date.