### PR TITLE
Fix permissions on `write_*` functions

### DIFF
--- a/R/write_data.R
+++ b/R/write_data.R
@@ -28,7 +28,10 @@ write_sav <- function(data, path, compress = "zsav") {
     compress = compress
   )
 
-  fs::file_chmod(path = path, mode = "660")
+  if (fs::file_info(path)$user == Sys.getenv("USER")) {
+    # Set the correct permissions
+    fs::file_chmod(path = path, mode = "660")
+  }
 
   return(invisible(data))
 }
@@ -60,7 +63,10 @@ write_rds <- function(data, path, compress = "xz", ...) {
     compression = 9
   )
 
-  fs::file_chmod(path = path, mode = "660")
+  if (fs::file_info(path)$user == Sys.getenv("USER")) {
+    # Set the correct permissions
+    fs::file_chmod(path = path, mode = "660")
+  }
 
   return(invisible(data))
 }


### PR DESCRIPTION
I was getting an error again here, by the same logic we used in `write_xlsx_tests` we should only try and change the permissions if we're the owner i.e. we just create the file.

I think the error message was being confused by the way we pipe the data to `write_zsav` followed by `write_rds`, and how R is lazily executing that pipe (it goes inside out). If you run the `write_*` bits seperately the error message is clearer.

This will need 2 people to test it properly!