### PR TITLE
Removed documentation for parameter that no longer exists

### DIFF
--- a/R/produce_source_nrs_tests.R
+++ b/R/produce_source_nrs_tests.R
@@ -7,7 +7,6 @@
 #'
 #' @param data new or old data for testing summary flags
 #' (data is from [get_source_extract_path()])
-#' @param max_min_vars variables used when selecting 'min-max' from [calculate_measures()]
 #'
 #' @return a dataframe with a count of each flag
 #' from [calculate_measures()]

--- a/man/produce_source_nrs_tests.Rd
+++ b/man/produce_source_nrs_tests.Rd
@@ -9,8 +9,6 @@ produce_source_nrs_tests(data)
 \arguments{
 \item{data}{new or old data for testing summary flags
 (data is from \code{\link[=get_source_extract_path]{get_source_extract_path()}})}
-
-\item{max_min_vars}{variables used when selecting 'min-max' from \code{\link[=calculate_measures]{calculate_measures()}}}
 }
 \value{
 a dataframe with a count of each flag


### PR DESCRIPTION
Had roxygen reference to parameter that we hard-coded instead, in `produce_source_nrs_tests.R`. Removed this.