### PR TITLE
Update the cost uplift macro

### DIFF
--- a/All_years/01-Macros/Macro-01-Universal.sps
+++ b/All_years/01-Macros/Macro-01-Universal.sps
@@ -36,9 +36,9 @@ Define !Delayed_Discharge_period()
     "Jul16_Jun22"
 !EndDefine.
 
-* Latest 'real' costs we have in the format CCYY e.g. 2018/19 = 2018 (no quotes).
+* Latest 'real' costs we have in the format CCYY e.g. 2022/23 = 2022 (no quotes).
 Define !latest_cost_year()
-    2018
+    2022
 !EndDefine.
 
 *******************************************************.

--- a/All_years/01-Macros/Macro-01-Universal.sps
+++ b/All_years/01-Macros/Macro-01-Universal.sps
@@ -283,13 +283,26 @@ Define !ReadCodeLookup()
 * Should not need changing unless something is broken or to update methodology.
 *******************************************************.
 * Creates a variable with the correct uplift factor.
-* It works out the difference in years (minimum of 0).
-* Take 1.01 (for 1%) to the power of the difference in years (minimum of 0).
+* We have set uplifts to use for 2020/21, 2021/22 and 2022/23, provided by Paul Leak.
+* For older years, don't uplift.
+* For years after 2022/23 uplift by an additional 1% per year after the latest cost year (2022/23) 
 * For non plics recids use uplift of 1 so we won't change anything.
 Define !create_uplift_var().
     * Filter to PLICs recids.
     Do if any(recid, "00B", "01B", "GLS", "02B", "04B", "AE2").
-        Compute uplift = ((1.01) ** max(0, !Concat(!unquote(!eval(!altfy)),  " - ", !eval(!latest_cost_year)))).
+        Do if !eval(!fy) = "2021".
+            Compute uplift = 1.015.
+        Else if !eval(!fy) = "2122".
+            Compute uplift = 1.015 * 1.041.
+        Else if !eval(!fy) = "2223".
+            Compute uplift = 1.015 * 1.041 * 1.062.
+        Else if !unquote(!eval(!altfy)) > !eval(!latest_cost_year).
+            Compute test2 = !Concat(!unquote(!eval(!altfy)),  " - ", !eval(!latest_cost_year)).
+            Compute test =  ((1.01) ** (!Concat(!unquote(!eval(!altfy)),  " - ", !eval(!latest_cost_year)))).
+            Compute uplift = (1.015 * 1.041 * 1.062) * ((1.01) ** (!Concat(!unquote(!eval(!altfy)),  " - ", !eval(!latest_cost_year)))).
+        Else.
+            Compute uplift = 1.
+        End if.
     Else.
         Compute uplift = 1.
     End if.


### PR DESCRIPTION
New numbers from Paul Leak for uplifting 2020/21, 2021/22 and 2022/23. Also uplift any future years beyond that by 1%.

I created a dummy dataset with a `recid` variable and tested with this code:
```
Define !latest_cost_year()
    2022
!EndDefine.

Define !fy()
    "2324"
!EndDefine.

!create_uplift_var.
execute.
```
Then tested changing the `fy` and the `latest_cost_year`
