### PR TITLE
Changed typo in substance misuse cohort assignment

### DIFF
--- a/2014-15/C07 Calculate pathways cohorts.sps
+++ b/2014-15/C07 Calculate pathways cohorts.sps
@@ -155,7 +155,7 @@ end repeat.
 compute F13 = 0.
 
 do repeat diag = diag1 diag2 diag3 diag4 diag5 diag6.
-    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F11"))).
+    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F13"))).
         compute F13 = 1.
     End If.
 end repeat.

--- a/2015-16/C07 Calculate pathways cohorts.sps
+++ b/2015-16/C07 Calculate pathways cohorts.sps
@@ -155,7 +155,7 @@ end repeat.
 compute F13 = 0.
 
 do repeat diag = diag1 diag2 diag3 diag4 diag5 diag6.
-    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F11"))).
+    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F13"))).
         compute F13 = 1.
     End If.
 end repeat.

--- a/2016-17/C07 Calculate pathways cohorts.sps
+++ b/2016-17/C07 Calculate pathways cohorts.sps
@@ -155,7 +155,7 @@ end repeat.
 compute F13 = 0.
 
 do repeat diag = diag1 diag2 diag3 diag4 diag5 diag6.
-    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F11"))).
+    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F13"))).
         compute F13 = 1.
     End If.
 end repeat.

--- a/2017-18/C07 Calculate pathways cohorts.sps
+++ b/2017-18/C07 Calculate pathways cohorts.sps
@@ -155,7 +155,7 @@ end repeat.
 compute F13 = 0.
 
 do repeat diag = diag1 diag2 diag3 diag4 diag5 diag6.
-    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F11"))).
+    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F13"))).
         compute F13 = 1.
     End If.
 end repeat.

--- a/2018-19/C07 Calculate pathways cohorts.sps
+++ b/2018-19/C07 Calculate pathways cohorts.sps
@@ -155,7 +155,7 @@ end repeat.
 compute F13 = 0.
 
 do repeat diag = diag1 diag2 diag3 diag4 diag5 diag6.
-    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F11"))).
+    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F13"))).
         compute F13 = 1.
     End If.
 end repeat.

--- a/2019-20/C07 Calculate pathways cohorts.sps
+++ b/2019-20/C07 Calculate pathways cohorts.sps
@@ -155,7 +155,7 @@ end repeat.
 compute F13 = 0.
 
 do repeat diag = diag1 diag2 diag3 diag4 diag5 diag6.
-    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F11"))).
+    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F13"))).
         compute F13 = 1.
     End If.
 end repeat.

--- a/2020-21/C07 Calculate pathways cohorts.sps
+++ b/2020-21/C07 Calculate pathways cohorts.sps
@@ -155,7 +155,7 @@ end repeat.
 compute F13 = 0.
 
 do repeat diag = diag1 diag2 diag3 diag4 diag5 diag6.
-    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F11"))).
+    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F13"))).
         compute F13 = 1.
     End If.
 end repeat.

--- a/2021-22/C07 Calculate pathways cohorts.sps
+++ b/2021-22/C07 Calculate pathways cohorts.sps
@@ -155,7 +155,7 @@ end repeat.
 compute F13 = 0.
 
 do repeat diag = diag1 diag2 diag3 diag4 diag5 diag6.
-    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F11"))).
+    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F13"))).
         compute F13 = 1.
     End If.
 end repeat.

--- a/2022-23/C07 Calculate pathways cohorts.sps
+++ b/2022-23/C07 Calculate pathways cohorts.sps
@@ -155,7 +155,7 @@ end repeat.
 compute F13 = 0.
 
 do repeat diag = diag1 diag2 diag3 diag4 diag5 diag6.
-    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F11"))).
+    Do If (any(recid, "01B", "04B") and (any(char.substr(diag, 1, 3), "F13"))).
         compute F13 = 1.
     End If.
 end repeat.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # December 2022 Update - Unreleased
+* Fixed a typo in the Service Use Cohort `substance` where the ICD-10 code `F11` (Opioids) was used instead of the correct `F13` (sedatives or hypnotics). 
 
 # September 2022 Update - Released 05-Sep-2022
 * Costs uplifted for 2021 onwards.


### PR DESCRIPTION
Changed "F11" to "F13" in each year's C07 file, to fix a typo. 