### PR TITLE
Create tests for GP OOH extract

### DIFF
--- a/Production_scripts/Process_extracts/extract_gp_ooh.R
+++ b/Production_scripts/Process_extracts/extract_gp_ooh.R
@@ -406,7 +406,8 @@ ooh_clean <- ooh_costs %>%
   ) %>%
   dplyr::mutate(
     record_keydate1 = as.Date(record_keydate1),
-    record_keydate2 = as.Date(record_keydate2))
+    record_keydate2 = as.Date(record_keydate2)
+  )
 
 # Keep the location descriptions as a lookup.
 # TODO write the GP OoH lookup out using some functions
@@ -462,8 +463,8 @@ final_data <- ooh_clean %>%
 
 rm(location_lookup, ooh_clean, ooh_costs)
 
-  # Save as rds file
-  final_data %>%
-    write_rds(get_source_extract_path(year, "GPOoH", check_mode = "write"))
+# Save as rds file
+final_data %>%
+  write_rds(get_source_extract_path(year, "GPOoH", check_mode = "write"))
 
 # End of Script #

--- a/Production_scripts/Process_extracts/extract_gp_ooh.R
+++ b/Production_scripts/Process_extracts/extract_gp_ooh.R
@@ -4,7 +4,7 @@
 library(createslf)
 
 # Specify year
-year <- check_year_format("1920")
+year <- check_year_format("1718")
 
 
 # Diagnosis Data ---------------------------------
@@ -403,7 +403,10 @@ ooh_clean <- ooh_costs %>%
     key_time2 = hms::as_hms(record_keydate2),
     record_keydate1 = trunc(record_keydate1, "days"),
     record_keydate2 = trunc(record_keydate2, "days")
-  )
+  ) %>%
+  dplyr::mutate(
+    record_keydate1 = as.Date(record_keydate1),
+    record_keydate2 = as.Date(record_keydate2))
 
 # Keep the location descriptions as a lookup.
 # TODO write the GP OoH lookup out using some functions

--- a/Production_scripts/Process_extracts/extract_gp_ooh.R
+++ b/Production_scripts/Process_extracts/extract_gp_ooh.R
@@ -461,4 +461,9 @@ final_data <- ooh_clean %>%
   )
 
 rm(location_lookup, ooh_clean, ooh_costs)
+
+  # Save as rds file
+  final_data %>%
+    write_rds(get_source_extract_path(year, "GPOoH", check_mode = "write"))
+
 # End of Script #

--- a/R/process_extract_prescribing.R
+++ b/R/process_extract_prescribing.R
@@ -27,11 +27,11 @@ process_extract_prescribing <- function(data, year, write_to_disk = TRUE) {
     dplyr::mutate(
       recid = "PIS",
       year = year,
-    # Recode GP Practice into a 5 digit number
-    # assume that if it starts with a letter it's an English practice
-    # and so recode to 99995
-    gpprac = convert_eng_gpprac_to_dummy(.data$gpprac)
-      ) %>%
+      # Recode GP Practice into a 5 digit number
+      # assume that if it starts with a letter it's an English practice
+      # and so recode to 99995
+      gpprac = convert_eng_gpprac_to_dummy(.data$gpprac)
+    ) %>%
     # Set date to the end of the FY
     dplyr::mutate(
       record_keydate1 = end_fy(year),

--- a/R/process_tests_gp_ooh.R
+++ b/R/process_tests_gp_ooh.R
@@ -14,9 +14,11 @@ process_tests_gp_ooh <- function(data, year) {
 
   comparison <- produce_test_comparison(
     old_data = produce_source_extract_tests(old_data,
-                                            sum_mean_vars = "cost"),
+      sum_mean_vars = "cost"
+    ),
     new_data = produce_source_extract_tests(data,
-                                            sum_mean_vars = "cost")
+      sum_mean_vars = "cost"
+    )
   ) %>%
     write_tests_xlsx(sheet_name = "GPOoH", year)
 

--- a/R/process_tests_gp_ooh.R
+++ b/R/process_tests_gp_ooh.R
@@ -1,0 +1,24 @@
+#' Process GP OOH tests
+#'
+#' @description This script takes the processed GP OOH extract and produces
+#' a test comparison with the previous data. This is written to disk as a csv.
+#'
+#' @param data The processed data extract
+#' @param year year of extract
+#'
+#' @return a csv document containing tests for extracts
+#' @export
+#'
+process_tests_gp_ooh <- function(data, year) {
+  old_data <- get_existing_data_for_tests(data)
+
+  comparison <- produce_test_comparison(
+    old_data = produce_source_extract_tests(old_data,
+                                            sum_mean_vars = "cost"),
+    new_data = produce_source_extract_tests(data,
+                                            sum_mean_vars = "cost")
+  ) %>%
+    write_tests_xlsx(sheet_name = "GPOoH", year)
+
+  return(comparison)
+}


### PR DESCRIPTION
Follows the same format as other tests and this is already in a function for processing. I made one tweak to the GP OOH extract to include a line for changing the type for `record_keydate1/2`. This is now in a date format which was preventing the comparison from returning. I have tested this and happy this is working to produce a similar output to other tests 