### PR TITLE
Fix bug in episode file tests

### DIFF
--- a/R/process_tests_episode_file.R
+++ b/R/process_tests_episode_file.R
@@ -56,8 +56,7 @@ produce_episode_file_tests <- function(
     max_min_vars = c(
       "record_keydate1", "record_keydate2",
       "cost_total_net", "yearstay"
-    ),
-    group_by = "recid") {
+    )) {
   test_flags <- data %>%
     dplyr::group_by(.data$recid) %>%
     # use functions to create HB and partnership flags
@@ -90,22 +89,22 @@ produce_episode_file_tests <- function(
     # keep variables for comparison
     dplyr::select(c("valid_chi":dplyr::last_col())) %>%
     # use function to sum new test flags
-    calculate_measures(measure = "sum", group_by = group_by)
+    calculate_measures(measure = "sum", group_by = "recid")
 
   all_measures <- data %>%
-    group_by(.data$recid) %>%
+    dplyr::group_by(.data$recid) %>%
     calculate_measures(
       vars = {{ sum_mean_vars }},
       measure = "all",
-      group_by = TRUE
+      group_by = "recid"
     )
 
   min_max <- data %>%
-    group_by(.data$recid) %>%
+    dplyr::group_by(.data$recid) %>%
     calculate_measures(
       vars = {{ max_min_vars }},
       measure = "min-max",
-      group_by = TRUE
+      group_by = "recid"
     )
 
   join_output <- list(

--- a/R/process_tests_episode_file.R
+++ b/R/process_tests_episode_file.R
@@ -40,7 +40,6 @@ process_tests_episode_file <- function(data, year) {
 #' 'all' measures from [calculate_measures()]
 #' @param max_min_vars variables used when selecting
 #' 'min-max' from [calculate_measures()]
-#' @inheritParams calculate_measures
 #'
 #' @return a dataframe with a count of each flag
 #' from [calculate_measures()]

--- a/R/run_episode_file.R
+++ b/R/run_episode_file.R
@@ -1,13 +1,13 @@
 #' Function for running the Source Episode file
 #'
-#' @param processed_data_list
-#' @param year
-#' @param write_to_disk
+#' @param processed_data_list containing data from processed extracts.
+#' @param year The year to process, in FY format.
+#' @param write_to_disk (optional) Should the data be written to disk default is
+#' `TRUE` i.e. write the data to disk.
 #'
-#' @return
+#' @return a dataframe containing the ep file
 #' @export
 #'
-#' @examples
 run_episode_file <- function(processed_data_list, year, write_to_disk = TRUE) {
   # Bring all the datasets together from Jen's process functions
   fixed_patient_types <- dplyr::bind_rows(processed_data_list) %>%

--- a/man/produce_episode_file_tests.Rd
+++ b/man/produce_episode_file_tests.Rd
@@ -7,8 +7,7 @@
 produce_episode_file_tests(
   data,
   sum_mean_vars = c("beddays", "cost", "yearstay"),
-  max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net", "yearstay"),
-  group_by = "recid"
+  max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net", "yearstay")
 )
 }
 \arguments{
@@ -20,9 +19,6 @@ produce_episode_file_tests(
 
 \item{max_min_vars}{variables used when selecting
 'min-max' from \code{\link[=calculate_measures]{calculate_measures()}}}
-
-\item{group_by}{Default as NULL for grouping variables. Specify
-variables for grouping e.g recid for episode file testing.}
 }
 \value{
 a dataframe with a count of each flag

--- a/man/run_episode_file.Rd
+++ b/man/run_episode_file.Rd
@@ -7,7 +7,15 @@
 run_episode_file(processed_data_list, year, write_to_disk = TRUE)
 }
 \arguments{
-\item{write_to_disk}{}
+\item{processed_data_list}{containing data from processed extracts.}
+
+\item{year}{The year to process, in FY format.}
+
+\item{write_to_disk}{(optional) Should the data be written to disk default is
+\code{TRUE} i.e. write the data to disk.}
+}
+\value{
+a dataframe containing the ep file
 }
 \description{
 Function for running the Source Episode file


### PR DESCRIPTION
Applying a fix to the episode file tests which was preventing this from running. The main issue was that dplyr was not supplied in a `group_by` and this was also `TRUE` which should have been `"recid"`. I have also updated the `run_episode_file` documentation here as this was failing.