### PR TITLE
Fix dn tests

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -67,10 +67,9 @@ pattype
 phs
 phsmethods
 phsopendata
-postcodes
 placeinc
+postcodes
 PPAs
-praccode
 prac
 praccode
 purrr
@@ -96,6 +95,7 @@ SMRA
 smrtype
 sparra
 spd
+SPSS
 spss
 stringdist
 stringr

--- a/R/process_tests_district_nursing.R
+++ b/R/process_tests_district_nursing.R
@@ -8,7 +8,10 @@
 #'
 #' @export
 process_tests_district_nursing <- function(data, year) {
-  old_data <- get_existing_data_for_tests(data)
+  old_data <- get_existing_data_for_tests(data) %>%
+    # replace NA by 0 in monthly costs
+    dplyr::mutate(dplyr::across(dplyr::ends_with("_cost"),
+                                ~ replace(.x, is.na(.x), 0)))
 
   comparison <- produce_test_comparison(
     old_data = produce_source_dn_tests(old_data),

--- a/R/process_tests_district_nursing.R
+++ b/R/process_tests_district_nursing.R
@@ -9,6 +9,7 @@
 #' @export
 process_tests_district_nursing <- function(data, year) {
   old_data <- get_existing_data_for_tests(data) %>%
+    # TODO: remove this bit after SPSS stopped
     # replace NA by 0 in monthly costs
     dplyr::mutate(dplyr::across(
       dplyr::ends_with("_cost"),

--- a/R/process_tests_district_nursing.R
+++ b/R/process_tests_district_nursing.R
@@ -10,8 +10,10 @@
 process_tests_district_nursing <- function(data, year) {
   old_data <- get_existing_data_for_tests(data) %>%
     # replace NA by 0 in monthly costs
-    dplyr::mutate(dplyr::across(dplyr::ends_with("_cost"),
-                                ~ replace(.x, is.na(.x), 0)))
+    dplyr::mutate(dplyr::across(
+      dplyr::ends_with("_cost"),
+      ~ replace(.x, is.na(.x), 0)
+    ))
 
   comparison <- produce_test_comparison(
     old_data = produce_source_dn_tests(old_data),

--- a/R/process_tests_district_nursing.R
+++ b/R/process_tests_district_nursing.R
@@ -12,7 +12,7 @@ process_tests_district_nursing <- function(data, year) {
     # replace NA by 0 in monthly costs
     dplyr::mutate(dplyr::across(
       dplyr::ends_with("_cost"),
-      ~ replace(.x, is.na(.x), 0)
+      ~ tidyr::replace_na(.x, 0)
     ))
 
   comparison <- produce_test_comparison(


### PR DESCRIPTION
The gap of mean monthly costs between SPSS and R results of DN is because of the SPSS results contains NA for 0 in monthly costs. Hence, replacing NA with 0 in the testing script can fix the gap.