### PR TITLE
replace NA with 0 when reading the extract of acute and mental health

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,4 +1,6 @@
+admloc
 admtype
+adtf
 aut
 bedday
 beddays
@@ -6,8 +8,12 @@ birthtime
 boxi
 cattend
 cij
+Classificat
 cmh
 CNWs
+commhosp
+costmonthnum
+costsfy
 covr
 cph
 createslf
@@ -19,6 +25,9 @@ datetime
 dbconnect
 dbplyr
 demog
+disch
+dischloc
+dischto
 dnas
 dontrun
 downup
@@ -39,6 +48,7 @@ hbnames
 hbpraccode
 hbrescode
 hbtreatcode
+HCP
 hhg
 hms
 homecare
@@ -55,10 +65,13 @@ magrittr
 Mcbride
 mcmahon
 MMMYY
+mpat
 multistaff
+nhshosp
 nrs
 nsu
 odbc
+oldtadm
 opendata
 openxlsx
 ORCID
@@ -67,10 +80,9 @@ pattype
 phs
 phsmethods
 phsopendata
-postcodes
 placeinc
+postcodes
 PPAs
-praccode
 prac
 praccode
 purrr
@@ -88,6 +100,8 @@ Rprofile
 rstudioapi
 Rtype
 seealso
+selfharm
+sigfac
 simd
 SLF
 slf
@@ -98,8 +112,11 @@ smrtype
 sparra
 spd
 spss
+stadm
 stringdist
 stringr
+submis
+tadm
 tbl
 telecare
 testthat

--- a/R/read_extract_acute.R
+++ b/R/read_extract_acute.R
@@ -150,7 +150,9 @@ read_extract_acute <- function(year, file_path = get_boxi_extract_path(year = ye
       cij_ipdc = "CIJ Inpatient Day Case Identifier Code (01)",
       lineno = "Line Number (01)",
       GLS_record = "GLS Record"
-    )
+    ) %>%
+    # replace NA in cost_total_net by 0
+    dplyr::mutate(cost_total_net = tidyr::replace_na(.data[["cost_total_net"]], 0))
 
   return(extract_acute)
 }

--- a/R/read_extract_mental_health.R
+++ b/R/read_extract_mental_health.R
@@ -127,7 +127,9 @@ read_extract_mental_health <- function(
       nhshosp = "NHS Hospital Flag (04)",
       commhosp = "Community Hospital Flag (04)",
       uri = "Unique Record Identifier"
-    )
+    ) %>%
+    # replace NA in cost_total_net by 0
+    dplyr::mutate(cost_total_net = tidyr::replace_na(.data[["cost_total_net"]], 0))
 
   return(extract_mental_health)
 }


### PR DESCRIPTION
The issue with acute test results is the mean total costs and monthly mean costs go slightly up. It is because Function `read_extract_acute` will give data with NA in `total_net_cost`. Hence, replacing NA with 0 can fix the issue.