### PR TITLE
Fix a Home Care bug

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -68,6 +68,7 @@ mcmahon
 MMMYY
 mpat
 multistaff
+NAs
 nhshosp
 nrs
 nsu

--- a/R/process_sc_all_home_care.R
+++ b/R/process_sc_all_home_care.R
@@ -54,6 +54,7 @@ process_sc_all_home_care <- function(data, sc_demographics = get_sc_demog_lookup
     # fill reablement when missing but present in group
     dplyr::group_by(.data$sending_location, .data$social_care_id, .data$hc_service_start_date) %>%
     tidyr::fill(.data$reablement, .direction = "updown") %>%
+    dplyr::mutate(reablement = tidyr::replace_na(.data$reablement, 9L)) %>%
     dplyr::ungroup() %>%
     # Only keep records which have some time in the quarter in which they were submitted
     dplyr::mutate(


### PR DESCRIPTION
Fix bug in Home Care where reablement was being left with NA (should be 9).

In the data `reablement` has both missing (NA) and 9. Unknown should be coded as 9. We first set all the 9s to NA, then use `tidyr::fill` to fill in from other records. The bit that was missed was replacing the remaining NAs with 9. 