### PR TITLE
Fix a bug in the SC Demographics

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -128,6 +128,7 @@ tidyselect
 uid
 ungroup
 updown
+upi
 xlsx
 yearstay
 zihao

--- a/R/process_lookup_sc_demographics.R
+++ b/R/process_lookup_sc_demographics.R
@@ -16,7 +16,7 @@ process_lookup_sc_demographics <- function(data, spd_path = get_spd_path(), writ
   ## Deal with postcodes---------------------------------------
 
   # UK postcode regex - see https://ideal-postcodes.co.uk/guides/postcode-validation
-  uk_pc_regexp <- "^[a-z]{1,2}\\d[a-z\\d]?\\s*\\d[a-z]{2}$"
+  uk_pc_regexp <- "^[A-Z]{1,2}[0-9][A-Z0-9]?\\s*[0-9][A-Z]{2}$"
 
   dummy_postcodes <- c("NK1 0AA", "NF1 1AB")
   non_existant_postcodes <- c("PR2 5AL", "M16 0GS", "DY103DJ")


### PR DESCRIPTION
This has probably been outstanding for some time.

`phsmethods::format_postcode` forces them to uppercase, so all the postcodes will definitely be uppercase. Previously the regex didn't match anything as it was only looking for lowercase (it probably should have been case insensitive.)

The regex now looks exclusively for uppercase so we should continue keeping valid postcodes from the SC data!