### PR TITLE
Use integers for appropriate variables

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -6,6 +6,7 @@ bedday
 beddays
 birthtime
 boxi
+carehome
 cattend
 cij
 Classificat
@@ -60,6 +61,7 @@ itle
 jennifer
 keydate
 keyring
+los
 ltc
 lubridate
 magrittr
@@ -69,6 +71,7 @@ MMMYY
 mpat
 multistaff
 nhshosp
+NRS
 nrs
 nsu
 odbc
@@ -128,6 +131,7 @@ tidyselect
 uid
 ungroup
 updown
+upi
 xlsx
 yearstay
 zihao

--- a/R/process_sc_all_alarms_telecare.R
+++ b/R/process_sc_all_alarms_telecare.R
@@ -50,8 +50,8 @@ process_sc_all_alarms_telecare <- function(data, sc_demographics = get_sc_demog_
     dplyr::mutate(
       recid = "AT",
       smrtype = dplyr::case_when(
-        .data$service_type == 1 ~ "AT-Alarm",
-        .data$service_type == 2 ~ "AT-Tele"
+        .data$service_type == 1L ~ "AT-Alarm",
+        .data$service_type == 2L ~ "AT-Tele"
       ),
       # Create person id variable
       person_id = glue::glue("{sending_location}-{social_care_id}"),

--- a/R/process_sc_all_care_home.R
+++ b/R/process_sc_all_care_home.R
@@ -31,15 +31,6 @@ process_sc_all_care_home <- function(data,
   ## Data Cleaning-----------------------------------------------------
   ch_clean <- data %>%
     dplyr::mutate(
-      dplyr::across(
-        c(
-          "ch_provider",
-          "reason_for_admission",
-          "type_of_admission",
-          "nursing_care_provision"
-        ),
-        as.integer
-      ),
       record_date = end_fy_quarter(.data[["period"]]),
       qtr_start = start_fy_quarter(.data[["period"]]),
       # Set missing admission date to start of the submitted quarter

--- a/R/process_sc_all_home_care.R
+++ b/R/process_sc_all_home_care.R
@@ -28,9 +28,9 @@ process_sc_all_home_care <- function(data, sc_demographics = get_sc_demog_lookup
 
   home_care_clean <- matched_hc_data %>%
     # set reablement values == 9 to NA
-    dplyr::mutate(reablement = dplyr::na_if(.data$reablement, "9")) %>%
+    dplyr::mutate(reablement = dplyr::na_if(.data$reablement, 9L)) %>%
     # fix NA hc_service
-    dplyr::mutate(hc_service = tidyr::replace_na(.data$hc_service, "0")) %>%
+    dplyr::mutate(hc_service = tidyr::replace_na(.data$hc_service, 0L)) %>%
     # period start and end dates
     dplyr::mutate(
       record_date = end_fy_quarter(.data$period),

--- a/R/process_sc_all_sds.R
+++ b/R/process_sc_all_sds.R
@@ -29,8 +29,8 @@ process_sc_all_sds <- function(data, sc_demographics = get_sc_demog_lookup_path(
     dplyr::mutate(dplyr::across(
       tidyselect::starts_with("sds_option_"),
       ~ dplyr::case_when(
-        .x == "1" ~ TRUE,
-        .x == "0" ~ FALSE,
+        .x == 1L ~ TRUE,
+        .x == 0L ~ FALSE,
         is.na(.x) ~ FALSE
       )
     )) %>%

--- a/R/process_tests_sc_demographics.R
+++ b/R/process_tests_sc_demographics.R
@@ -35,16 +35,8 @@ produce_sc_demog_lookup_tests <- function(data) {
     # create test flags
     create_demog_test_flags() %>%
     dplyr::mutate(
-      n_missing_sending_loc = dplyr::if_else(
-        is_missing(.data$sending_location),
-        1L,
-        0L
-      ),
-      n_missing_sc_id = dplyr::if_else(
-        is_missing(.data$social_care_id),
-        1L,
-        0L
-      )
+      n_missing_sending_loc = is.na(.data$sending_location),
+      n_missing_sc_id = is.na(.data$social_care_id)
     ) %>%
     # remove variables that won't be summed
     dplyr::select(

--- a/R/read_lookup_sc_demographics.R
+++ b/R/read_lookup_sc_demographics.R
@@ -6,28 +6,32 @@
 #' @export
 #'
 read_lookup_sc_demographics <- function(sc_connection = phs_db_connection(dsn = "DVPROD")) {
-  # Read in data---------------------------------------
-
-  # read in data - social care 2 demographic
   sc_demog <- dplyr::tbl(
     sc_connection,
-    dbplyr::in_schema(
-      "social_care_2",
-      "demographic_snapshot"
-    )
+    dbplyr::in_schema("social_care_2", "demographic_snapshot")
   ) %>%
     dplyr::select(
-      "latest_record_flag", "extract_date", "sending_location", "social_care_id", "upi",
-      "chi_upi", "submitted_postcode", "chi_postcode", "submitted_date_of_birth",
-      "chi_date_of_birth", "submitted_gender", "chi_gender_code"
+      "latest_record_flag",
+      "extract_date",
+      "sending_location",
+      "social_care_id",
+      "upi",
+      "chi_upi",
+      "submitted_postcode",
+      "chi_postcode",
+      "submitted_date_of_birth",
+      "chi_date_of_birth",
+      "submitted_gender",
+      "chi_gender_code"
     ) %>%
-    dplyr::collect()
-
-  # variable types
-  sc_demog <- sc_demog %>%
+    dplyr::collect() %>%
     dplyr::mutate(
-      submitted_gender = as.numeric(.data$submitted_gender),
-      chi_gender_code = as.numeric(.data$chi_gender_code)
+      dplyr::across(c(
+        "latest_record_flag",
+        "sending_location",
+        "submitted_gender",
+        "chi_gender_code"
+      ), as.integer)
     )
 
   return(sc_demog)

--- a/R/read_sc_all_alarms_telecare.R
+++ b/R/read_sc_all_alarms_telecare.R
@@ -30,7 +30,10 @@ read_sc_all_alarms_telecare <- function(sc_dvprod_connection = phs_db_connection
     ) %>%
     # order
     dplyr::arrange(.data$sending_location, .data$social_care_id) %>%
-    dplyr::collect()
+    dplyr::collect() %>%
+    dplyr::mutate(
+      dplyr::across(c("sending_location", "service_type"), as.integer)
+    )
 
   return(at_full_data)
 }

--- a/R/read_sc_all_care_home.R
+++ b/R/read_sc_all_care_home.R
@@ -7,9 +7,6 @@
 #' @export
 #'
 read_sc_all_care_home <- function(sc_dvprod_connection = phs_db_connection(dsn = "DVPROD")) {
-  # Read in data---------------------------------------
-
-  ## read in data - social care 2 demographic
   ch_data <- dplyr::tbl(
     sc_dvprod_connection,
     dbplyr::in_schema("social_care_2", "carehome_snapshot")
@@ -43,7 +40,17 @@ read_sc_all_care_home <- function(sc_dvprod_connection = phs_db_connection(dsn =
         .data$period
       )
     ) %>%
-    dplyr::collect()
+    dplyr::select(!c("financial_year", "financial_quarter")) %>%
+    dplyr::collect() %>%
+    dplyr::mutate(
+      dplyr::across(c(
+        "sending_location",
+        "ch_provider",
+        "reason_for_admission",
+        "type_of_admission",
+        "nursing_care_provision"
+      ), as.integer)
+    )
 
   return(ch_data)
 }

--- a/R/read_sc_all_care_home.R
+++ b/R/read_sc_all_care_home.R
@@ -16,8 +16,6 @@ read_sc_all_care_home <- function(sc_dvprod_connection = phs_db_connection(dsn =
       "ch_postcode",
       "sending_location",
       "social_care_id",
-      "financial_year",
-      "financial_quarter",
       "period",
       "ch_provider",
       "reason_for_admission",
@@ -28,19 +26,11 @@ read_sc_all_care_home <- function(sc_dvprod_connection = phs_db_connection(dsn =
       "age"
     ) %>%
     # Correct FY 2017
-    dplyr::mutate(
-      financial_quarter = dplyr::if_else(
-        .data$financial_year == 2017L & is.na(.data$financial_quarter),
-        4L,
-        .data$financial_quarter
-      ),
-      period = dplyr::if_else(
-        .data$financial_year == 2017L & .data$financial_quarter == 4L,
-        "2017Q4",
-        .data$period
-      )
-    ) %>%
-    dplyr::select(!c("financial_year", "financial_quarter")) %>%
+    dplyr::mutate(period = dplyr::if_else(
+      .data$period == "2017",
+      "2017Q4",
+      .data$period
+    )) %>%
     dplyr::collect() %>%
     dplyr::mutate(
       dplyr::across(c(

--- a/R/read_sc_all_home_care.R
+++ b/R/read_sc_all_home_care.R
@@ -19,7 +19,6 @@ read_sc_all_home_care <- function(sc_dvprod_connection = phs_db_connection(dsn =
       "hc_service_end_date",
       "period",
       "financial_year",
-      "financial_quarter",
       "hc_service",
       "hc_service_provider",
       "reablement",
@@ -29,14 +28,6 @@ read_sc_all_home_care <- function(sc_dvprod_connection = phs_db_connection(dsn =
       "hc_start_date_after_end_date"
     ) %>%
     # fix 2017
-    dplyr::mutate(
-      financial_quarter =
-        dplyr::if_else(
-          .data$financial_year == 2017L & is.na(.data$financial_quarter),
-          4,
-          .data$financial_quarter
-        )
-    ) %>%
     dplyr::mutate(period = dplyr::if_else(
       .data$period == "2017",
       "2017Q4",
@@ -44,7 +35,7 @@ read_sc_all_home_care <- function(sc_dvprod_connection = phs_db_connection(dsn =
     )) %>%
     # drop rows start date after end date
     dplyr::filter(.data$hc_start_date_after_end_date == 0L) %>%
-    dplyr::select(!c("financial_quarter", "hc_start_date_after_end_date")) %>%
+    dplyr::select(!"hc_start_date_after_end_date") %>%
     dplyr::collect() %>%
     dplyr::mutate(dplyr::across(c(
       "sending_location",

--- a/R/read_sc_all_home_care.R
+++ b/R/read_sc_all_home_care.R
@@ -7,10 +7,10 @@
 #' @export
 #'
 read_sc_all_home_care <- function(sc_dvprod_connection = phs_db_connection(dsn = "DVPROD")) {
-  # Read in data---------------------------------------
-
-  # read in data - social care 2 home care
-  home_care_data <- dplyr::tbl(sc_dvprod_connection, dbplyr::in_schema("social_care_2", "homecare_snapshot")) %>%
+  home_care_data <- dplyr::tbl(
+    sc_dvprod_connection,
+    dbplyr::in_schema("social_care_2", "homecare_snapshot")
+  ) %>%
     dplyr::select(
       "sending_location",
       "sending_location_name",
@@ -31,15 +31,28 @@ read_sc_all_home_care <- function(sc_dvprod_connection = phs_db_connection(dsn =
     # fix 2017
     dplyr::mutate(
       financial_quarter =
-        dplyr::if_else(.data$financial_year == 2017L & is.na(.data$financial_quarter),
+        dplyr::if_else(
+          .data$financial_year == 2017L & is.na(.data$financial_quarter),
           4,
           .data$financial_quarter
         )
     ) %>%
-    dplyr::mutate(period = dplyr::if_else(.data$period == "2017", "2017Q4", .data$period)) %>%
+    dplyr::mutate(period = dplyr::if_else(
+      .data$period == "2017",
+      "2017Q4",
+      .data$period
+    )) %>%
     # drop rows start date after end date
     dplyr::filter(.data$hc_start_date_after_end_date == 0L) %>%
-    dplyr::collect()
+    dplyr::select(!c("financial_quarter", "hc_start_date_after_end_date")) %>%
+    dplyr::collect() %>%
+    dplyr::mutate(dplyr::across(c(
+      "sending_location",
+      "financial_year",
+      "hc_service",
+      "hc_service_provider",
+      "reablement"
+    ), as.integer))
 
   return(home_care_data)
 }

--- a/R/read_sc_all_sds.R
+++ b/R/read_sc_all_sds.R
@@ -7,8 +7,10 @@
 #' @export
 #'
 read_sc_all_sds <- function(sc_dvprod_connection = phs_db_connection(dsn = "DVPROD")) {
-  # Read in data---------------------------------------
-  sds_full_data <- dplyr::tbl(sc_dvprod_connection, dbplyr::in_schema("social_care_2", "sds_snapshot")) %>%
+  sds_full_data <- dplyr::tbl(
+    sc_dvprod_connection,
+    dbplyr::in_schema("social_care_2", "sds_snapshot")
+  ) %>%
     dplyr::select(
       "sending_location",
       "social_care_id",
@@ -19,7 +21,13 @@ read_sc_all_sds <- function(sc_dvprod_connection = phs_db_connection(dsn = "DVPR
       "sds_option_2",
       "sds_option_3"
     ) %>%
-    dplyr::collect()
+    dplyr::collect() %>%
+    dplyr::mutate(dplyr::across(c(
+      "sending_location",
+      "sds_option_1",
+      "sds_option_2",
+      "sds_option_3"
+    ), as.integer))
 
   return(sds_full_data)
 }


### PR DESCRIPTION
This fixes a bug where the client file was storing `sending_location` as an integer and couldn't be matched against the character type in the other files. Other variables will take less storage as an integer, likewise, a couple of variables which aren't actually needed are now dropped earlier.
