### PR TITLE
Convert NSU files into parquet format

### DIFF
--- a/R/add_nsu_cohort.R
+++ b/R/add_nsu_cohort.R
@@ -27,7 +27,7 @@ add_nsu_cohort <- function(data, year) {
 
   matched <- dplyr::full_join(data,
     # NSU cohort file
-    read_file(get_nsu_path(year, ext = "zsav")) %>%
+    read_file(get_nsu_path(year)) %>%
       dplyr::mutate(
         dob = as.Date(.data[["dob"]]),
         gpprac = convert_eng_gpprac_to_dummy(.data[["gpprac"]])

--- a/R/get_nsu_paths.R
+++ b/R/get_nsu_paths.R
@@ -12,7 +12,7 @@
 get_nsu_path <- function(year, ...) {
   nsu_file_path <- get_file_path(
     directory = fs::path(get_slf_dir(), "NSU"),
-    file_name = glue::glue("All_CHIs_20{year}.rds"),
+    file_name = glue::glue("All_CHIs_20{year}.gz.parquet"),
     ...
   )
 


### PR DESCRIPTION
Addresses Issue #578. 

NSU files are now saved in parquet format. This PR also updates the functions file paths to use parquet in `get_nsu_paths`.