### PR TITLE
Fix a misnamed variable in `correct_demographics`

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -2,6 +2,7 @@ Accom
 admloc
 admtype
 adtf
+arth
 aut
 bedday
 beddays
@@ -19,6 +20,7 @@ cls
 cmh
 CNWs
 commhosp
+congen
 costmonthnum
 costsfy
 covr

--- a/R/correct_demographics.R
+++ b/R/correct_demographics.R
@@ -21,7 +21,7 @@ correct_demographics <- function(data, year) {
         chi_check = FALSE,
         min_date = lubridate::ymd("1900-01-01"),
         max_date = pmin(
-          .data$keydate1_dateformat,
+          .data$record_keydate1,
           lubridate::ymd("1999-12-31"),
           na.rm = TRUE
         )
@@ -33,7 +33,7 @@ correct_demographics <- function(data, year) {
         chi_check = FALSE,
         min_date = lubridate::ymd("2000-01-01"),
         max_date = pmax(
-          .data$keydate1_dateformat,
+          .data$record_keydate1,
           lubridate::ymd("2000-01-01"),
           na.rm = TRUE
         )

--- a/R/fill_geographies.R
+++ b/R/fill_geographies.R
@@ -355,8 +355,8 @@ fill_data_from_chi <- function(data, type = c("postcode", "gpprac")) {
     # Sort by episode dates so that the fill will use the
     # 'nearest in time' postcode/gpprac
     dplyr::arrange(
-      .data$keydate1_dateformat,
-      .data$keydate2_dateformat,
+      .data$record_keydate1,
+      .data$record_keydate2,
       .by_group = TRUE
     )
 


### PR DESCRIPTION
We were testing with the old files which had `keydate*` as the date variable but in the new file we only have `record_keydate*` which is of a date type.