### PR TITLE
Resolve #642 error in creating Acute smrtype

### DIFF
--- a/R/add_smr_type.R
+++ b/R/add_smr_type.R
@@ -138,7 +138,8 @@ add_smr_type <- function(recid,
       recid == "01B" & ipdc == "I" ~ "Acute-IP",
       recid == "01B" & ipdc == "D" ~ "Acute-DC",
       recid == "GLS" & ipdc == "I" ~ "GLS-IP",
-      TRUE ~ "Acute-Unknown"
+      recid == "GLS" ~ "GLS-Unknown",
+      .default = "Acute-Unknown"
     )
   } else if (all(recid == "HC")) {
     # Home care

--- a/R/add_smr_type.R
+++ b/R/add_smr_type.R
@@ -109,7 +109,7 @@ add_smr_type <- function(recid,
 
   # Situation where an Acute/GLS recid is given but no ipdc marker
   if (any(recid %in% c("01B", "GLS")) & missing(ipdc)) {
-    cli::cli_warn(
+    cli::cli_abort(
       "An {.var ipdc} vector has not been supplied, and therefore Acute/GLS
                    records cannot be given an {.var smrtype}"
     )

--- a/R/add_smr_type.R
+++ b/R/add_smr_type.R
@@ -152,7 +152,7 @@ add_smr_type <- function(recid,
     smrtype <- dplyr::case_when(
       recid == "HC" & hc_service == 1L ~ "HC-Non-Per",
       recid == "HC" & hc_service == 2L ~ "HC-Per",
-      TRUE ~ "HC-Unknown"
+      .default = "HC-Unknown"
     )
   } else if (all(recid == "HL1")) {
     # Homelessness
@@ -170,7 +170,7 @@ add_smr_type <- function(recid,
       consultation_type == "COVID19 ASSESSMENT" ~ "OOH-C19Ass",
       consultation_type == "COVID19 ADVICE" ~ "OOH-C19Adv",
       consultation_type == "COVID19 OTHER" ~ "OOH-C19Oth",
-      TRUE ~ "OOH-Other"
+      .default = "OOH-Other"
     )
   } else {
     # Recids that can be recoded with no identifier

--- a/R/add_smr_type.R
+++ b/R/add_smr_type.R
@@ -63,9 +63,15 @@ add_smr_type <- function(recid,
 
   # Situation where acute records are present without a corresponding ipdc
   if (all(recid %in% c("01B", "GLS")) & anyNA(ipdc)) {
+    if (all(is.na(ipdc))) {
+      cli::cli_abort(
+        "In Acute records, {.var ipdc} is required to assign an smrtype, but
+        all values are {.val NA}. Please check the code/data."
+      )
+                    }
     cli::cli_warn(
-      "In Acute records, {.var ipdc} is required to assign an smrtype,
-                    and there are some {.val NA} values. Please check the data."
+      "In Acute records, {.var ipdc} is required to assign an smrtype, and
+      there are some {.val NA} values. Please check the data."
     )
   }
 

--- a/R/add_smr_type.R
+++ b/R/add_smr_type.R
@@ -63,7 +63,7 @@ add_smr_type <- function(recid,
 
   # Situation where acute records are present without a corresponding ipdc
   if (all(recid %in% c("01B", "GLS")) & anyNA(ipdc)) {
-    cli::cli_abort(
+    cli::cli_warn(
       "In Acute records, {.var ipdc} is required to assign an smrtype,
                     and there are some {.val NA} values. Please check the data."
     )
@@ -103,7 +103,7 @@ add_smr_type <- function(recid,
 
   # Situation where an Acute/GLS recid is given but no ipdc marker
   if (any(recid %in% c("01B", "GLS")) & missing(ipdc)) {
-    cli::cli_abort(
+    cli::cli_warn(
       "An {.var ipdc} vector has not been supplied, and therefore Acute/GLS
                    records cannot be given an {.var smrtype}"
     )
@@ -137,7 +137,8 @@ add_smr_type <- function(recid,
     smrtype <- dplyr::case_when(
       recid == "01B" & ipdc == "I" ~ "Acute-IP",
       recid == "01B" & ipdc == "D" ~ "Acute-DC",
-      recid == "GLS" & ipdc == "I" ~ "GLS-IP"
+      recid == "GLS" & ipdc == "I" ~ "GLS-IP",
+      TRUE ~ "Acute-Unknown"
     )
   } else if (all(recid == "HC")) {
     # Home care

--- a/R/add_smr_type.R
+++ b/R/add_smr_type.R
@@ -68,7 +68,7 @@ add_smr_type <- function(recid,
         "In Acute records, {.var ipdc} is required to assign an smrtype, but
         all values are {.val NA}. Please check the code/data."
       )
-                    }
+    }
     cli::cli_warn(
       "In Acute records, {.var ipdc} is required to assign an smrtype, and
       there are some {.val NA} values. Please check the data."


### PR DESCRIPTION
In 2022/23 file there was one record where idpc was `NA` which was causing an error when trying to add the smrtype for acute. I have now added this as `Acute-Unknown` and also changed the error messages to warnings instead. Tested this on `process_extract_acute` and happy this is working.