### PR TITLE
Fix bug with monthly cost/beddays

### DIFF
--- a/R/add_smr_type.R
+++ b/R/add_smr_type.R
@@ -63,7 +63,7 @@ add_smr_type <- function(recid,
 
   # Situation where acute records are present without a corresponding ipdc
   if (all(recid %in% c("01B", "GLS")) & anyNA(ipdc)) {
-    cli::cli_abort(
+    cli::cli_warn(
       "In Acute records, {.var ipdc} is required to assign an smrtype,
                     and there are some {.val NA} values. Please check the data."
     )
@@ -103,7 +103,7 @@ add_smr_type <- function(recid,
 
   # Situation where an Acute/GLS recid is given but no ipdc marker
   if (any(recid %in% c("01B", "GLS")) & missing(ipdc)) {
-    cli::cli_abort(
+    cli::cli_warn(
       "An {.var ipdc} vector has not been supplied, and therefore Acute/GLS
                    records cannot be given an {.var smrtype}"
     )
@@ -137,7 +137,8 @@ add_smr_type <- function(recid,
     smrtype <- dplyr::case_when(
       recid == "01B" & ipdc == "I" ~ "Acute-IP",
       recid == "01B" & ipdc == "D" ~ "Acute-DC",
-      recid == "GLS" & ipdc == "I" ~ "GLS-IP"
+      recid == "GLS" & ipdc == "I" ~ "GLS-IP",
+      TRUE ~ "Acute-Unknown"
     )
   } else if (all(recid == "HC")) {
     # Home care

--- a/R/convert_monthly_rows_to_vars.R
+++ b/R/convert_monthly_rows_to_vars.R
@@ -31,7 +31,7 @@ convert_monthly_rows_to_vars <- function(data,
     ) %>%
     dplyr::select(
       !dplyr::ends_with(c("_beddays", "_cost")),
-      stringr::str_glue("{month_order}_beddays"),
-      stringr::str_glue("{month_order}_cost")
+      dplyr::any_of(paste0(month_order, "_beddays")),
+      dplyr::any_of(paste0(month_order, "_cost"))
     )
 }


### PR DESCRIPTION
Issue here was that the `convert_monthly_rows_to_vars` function was returning an error due to the way this function was selecting variables ending `xxx_cost` and `xxx_beddays` which did not exist in the data e.g 2022/23 file where all months are not available. This has now been corrected using the `any_of()` function. I also have brought this branch up to date with #644 as otherwise this would have created conflicts and i was testing the same data and running into the issues in #644 