### PR TITLE
Update geography lookups to use parquet format

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -58,6 +58,7 @@ Eileanan
 envir
 feb
 fileext
+Finalise
 fst
 ftm
 fyear
@@ -181,6 +182,7 @@ tidyselect
 TODOs
 uid
 ungroup
+Unicode
 updown
 upi
 vline

--- a/R/get_lookup_paths.R
+++ b/R/get_lookup_paths.R
@@ -48,7 +48,7 @@ get_locality_path <- function(file_name = NULL, ext = "rds") {
 #' @export
 #'
 #' @family lookup file paths
-get_spd_path <- function(file_name = NULL, ext = "rds") {
+get_spd_path <- function(file_name = NULL, ext = "parquet") {
   spd_dir <-
     fs::path(
       get_lookups_dir(),
@@ -78,7 +78,7 @@ get_spd_path <- function(file_name = NULL, ext = "rds") {
 #' @export
 #'
 #' @family lookup file paths
-get_simd_path <- function(file_name = NULL, ext = "rds") {
+get_simd_path <- function(file_name = NULL, ext = "parquet") {
   simd_dir <-
     fs::path(get_lookups_dir(), "Deprivation")
 

--- a/R/process_lookup_postcode.R
+++ b/R/process_lookup_postcode.R
@@ -21,7 +21,7 @@ process_lookup_postcode <- function(spd_path = get_spd_path(),
   # postcode data
   spd_file <- read_file(spd_path) %>%
     dplyr::select(
-      .data$pc7,
+      "pc7",
       tidyselect::matches("datazone\\d{4}$"),
       tidyselect::matches("hb\\d{4}$"),
       tidyselect::matches("hscp\\d{4}$"),
@@ -36,7 +36,7 @@ process_lookup_postcode <- function(spd_path = get_spd_path(),
   # simd data
   simd_file <- read_file(simd_path) %>%
     dplyr::select(
-      .data$pc7,
+      "pc7",
       tidyselect::matches("simd\\d{4}.?.?_rank"),
       tidyselect::matches("simd\\d{4}.?.?_sc_decile"),
       tidyselect::matches("simd\\d{4}.?.?_sc_quintile"),
@@ -49,11 +49,11 @@ process_lookup_postcode <- function(spd_path = get_spd_path(),
   # locality
   locality_file <- read_file(locality_path) %>%
     dplyr::select(
-      locality = .data$hscp_locality,
+      locality = "hscp_locality",
       tidyselect::matches("datazone\\d{4}$")
     ) %>%
     dplyr::mutate(
-      locality = tidyr::replace_na(.data$locality, "No Locality Information")
+      locality = tidyr::replace_na("locality", "No Locality Information")
     )
 
 
@@ -69,9 +69,9 @@ process_lookup_postcode <- function(spd_path = get_spd_path(),
   outfile <-
     data %>%
     dplyr::select(
-      .data$postcode,
-      .data$lca,
-      .data$locality,
+      "postcode",
+      "lca",
+      "locality",
       tidyselect::matches("datazone\\d{4}$")[1L],
       tidyselect::matches("hb\\d{4}$(?:20[2-9]\\d)|(?:201[89])$"),
       tidyselect::matches("hscp\\d{4}$(?:20[2-9]\\d)|(?:201[89])$"),

--- a/man/get_simd_path.Rd
+++ b/man/get_simd_path.Rd
@@ -4,7 +4,7 @@
 \alias{get_simd_path}
 \title{SIMD File Path}
 \usage{
-get_simd_path(file_name = NULL, ext = "rds")
+get_simd_path(file_name = NULL, ext = "parquet")
 }
 \arguments{
 \item{file_name}{The file name (with extension if not supplied to \code{ext})}

--- a/man/get_spd_path.Rd
+++ b/man/get_spd_path.Rd
@@ -4,7 +4,7 @@
 \alias{get_spd_path}
 \title{Scottish Postcode Directory File Path}
 \usage{
-get_spd_path(file_name = NULL, ext = "rds")
+get_spd_path(file_name = NULL, ext = "parquet")
 }
 \arguments{
 \item{file_name}{The file name (with extension if not supplied to \code{ext})}


### PR DESCRIPTION
Update to use the new parquet files for geographies. Tested the files and happy they are working against our code. I've also updated some of the code to reflect those deprecated in tidyselect 1.2.0.