### PR TITLE
Tweaks to DN

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -11,6 +11,7 @@ beddays
 birthtime
 bodyloc
 boxi
+callr
 Canx
 carehome
 careinspectorate
@@ -29,6 +30,7 @@ covr
 cph
 createslf
 dataframe
+datamart
 datazone
 dateformat
 dateop
@@ -163,6 +165,7 @@ SMRA
 smrtype
 SPARRA
 spd
+SPSS
 spss
 stadm
 stefanzweifel

--- a/R/process_extract_district_nursing.R
+++ b/R/process_extract_district_nursing.R
@@ -97,20 +97,25 @@ process_extract_district_nursing <- function(
   dn_episodes <- care_marker %>%
     dplyr::group_by(.data$year, .data$chi, .data$ccm) %>%
     dplyr::summarise(
-      recid = dplyr::first(.data$recid),
-      smrtype = dplyr::first(.data$smrtype),
       record_keydate1 = min(.data$record_keydate1),
       record_keydate2 = max(.data$record_keydate1),
-      dob = dplyr::last(.data$dob),
-      gender = dplyr::last(.data$gender),
-      gpprac = dplyr::last(.data$gpprac),
-      age = dplyr::last(.data$age),
-      postcode = dplyr::last(.data$postcode),
-      datazone = dplyr::last(.data$datazone),
-      lca = dplyr::last(.data$lca),
-      hscp = dplyr::last(.data$hscp),
-      hbrescode = dplyr::last(.data$hbrescode),
-      hbtreatcode = dplyr::last(.data$hbtreatcode),
+      dplyr::across(
+        c(
+          "recid",
+          "smrtype",
+          "dob",
+          "age",
+          "gender",
+          "gpprac",
+          "postcode",
+          "datazone",
+          "lca",
+          "hscp",
+          "hbrescode",
+          "hbtreatcode"
+        ),
+        ~ dplyr::last(.x)
+      ),
       location = dplyr::first(.data$location_contact),
       diag1 = dplyr::first(.data$primary_intervention),
       diag2 = dplyr::first(.data$intervention_1),
@@ -119,24 +124,17 @@ process_extract_district_nursing <- function(
       diag5 = dplyr::last(.data$intervention_1),
       diag6 = dplyr::last(.data$intervention_2),
       total_no_dn_contacts = dplyr::n(),
-      cost_total_net = sum(.data$cost_total_net),
-      apr_cost = sum(.data$apr_cost),
-      may_cost = sum(.data$may_cost),
-      jun_cost = sum(.data$jun_cost),
-      jul_cost = sum(.data$jul_cost),
-      aug_cost = sum(.data$aug_cost),
-      sep_cost = sum(.data$sep_cost),
-      oct_cost = sum(.data$oct_cost),
-      nov_cost = sum(.data$nov_cost),
-      dec_cost = sum(.data$dec_cost),
-      jan_cost = sum(.data$jan_cost),
-      feb_cost = sum(.data$feb_cost),
-      mar_cost = sum(.data$mar_cost)
+      dplyr::across(
+        c(
+          "cost_total_net",
+          dplyr::ends_with("_cost")
+        ),
+        ~ sum(.x)
+      )
     ) %>%
     dplyr::ungroup()
 
   if (write_to_disk) {
-    # Save as rds file
     dn_episodes %>%
       write_file(get_source_extract_path(year, "DN", check_mode = "write"))
   }

--- a/R/process_extract_district_nursing.R
+++ b/R/process_extract_district_nursing.R
@@ -6,13 +6,19 @@
 #'
 #' @param data The extract to process
 #' @param year The year to process, in FY format.
+#' @param costs The cost lookup
 #' @param write_to_disk (optional) Should the data be written to disk default is
 #' `TRUE` i.e. write the data to disk.
 #'
 #' @return the final data as a [tibble][tibble::tibble-package].
 #' @export
 #' @family process extracts
-process_extract_district_nursing <- function(data, year, write_to_disk = TRUE) {
+process_extract_district_nursing <- function(
+    data,
+    year,
+    costs = read_file(get_dn_costs_path()),
+    write_to_disk = TRUE
+    ) {
   # Only run for a single year
   stopifnot(length(year) == 1L)
 
@@ -53,7 +59,7 @@ process_extract_district_nursing <- function(data, year, write_to_disk = TRUE) {
       )
     ) %>%
     # match files with DN Cost Lookup
-    dplyr::left_join(read_file(get_dn_costs_path()),
+    dplyr::left_join(costs,
       by = c("hbtreatcode", "year")
     ) %>%
     # costs are rough estimates we round them to the nearest pound

--- a/R/process_extract_district_nursing.R
+++ b/R/process_extract_district_nursing.R
@@ -17,8 +17,7 @@ process_extract_district_nursing <- function(
     data,
     year,
     costs = read_file(get_dn_costs_path()),
-    write_to_disk = TRUE
-    ) {
+    write_to_disk = TRUE) {
   # Only run for a single year
   stopifnot(length(year) == 1L)
 

--- a/R/read_extract_district_nursing.R
+++ b/R/read_extract_district_nursing.R
@@ -19,8 +19,6 @@ read_extract_district_nursing <- function(
       `Primary Intervention Category` = col_character(),
       `Other Intervention Category (1)` = col_character(),
       `Other Intervention Category (2)` = col_character(),
-      `Other Intervention Category (3)` = col_character(),
-      `Other Intervention Category (4)` = col_character(),
       `UPI Number [C]` = col_character(),
       `Patient DoB Date [C]` = col_date(format = "%Y/%m/%d %T"),
       `Patient Postcode [C] (Contact)` = col_character(),

--- a/_targets.R
+++ b/_targets.R
@@ -259,6 +259,7 @@ list(
     tar_target(source_dn_extract, process_extract_district_nursing(
       dn_data,
       year,
+      costs = dn_cost_lookup,
       write_to_disk = write_to_disk
     )),
     tar_target(source_homelessness_extract, process_extract_homelessness(

--- a/man/process_extract_district_nursing.Rd
+++ b/man/process_extract_district_nursing.Rd
@@ -4,12 +4,19 @@
 \alias{process_extract_district_nursing}
 \title{Process the District Nursing extract}
 \usage{
-process_extract_district_nursing(data, year, write_to_disk = TRUE)
+process_extract_district_nursing(
+  data,
+  year,
+  costs = read_file(get_dn_costs_path()),
+  write_to_disk = TRUE
+)
 }
 \arguments{
 \item{data}{The extract to process}
 
 \item{year}{The year to process, in FY format.}
+
+\item{costs}{The cost lookup}
 
 \item{write_to_disk}{(optional) Should the data be written to disk default is
 \code{TRUE} i.e. write the data to disk.}


### PR DESCRIPTION
The main change here is to recode `hbtreatcode` back to using HB2018 variables. This should correct the issue we saw in tests where some people (and their costs) had moved between Lanarkshire and Glasgow. I suspect that the datamart used to use HB2018 and has only recently switched to HB2019 as the R code seemed to be the same as the SPSS.

Some other changes I made were to expose the cost lookup as a parameter and add this to targets so that it now explicitly depends on the cost lookup. Otherwise, some minor tweaks to make the code more readable etc.