### PR TITLE
Fix bug in delayed discharges

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -17,6 +17,7 @@ carehome
 careinspectorate
 cattend
 CCYY
+cennum
 chp
 chpstart
 cij
@@ -108,6 +109,7 @@ magrittr
 Mcbride
 mcmahon
 MMMYY
+monthflag
 Moohan
 mpat
 multiday

--- a/R/read_extract_delayed_discharges.R
+++ b/R/read_extract_delayed_discharges.R
@@ -9,14 +9,6 @@ read_extract_delayed_discharges <- function(file_path = get_dd_path()) {
   extract_delayed_discharges <- read_file(file_path) %>%
     janitor::clean_names() %>%
     dplyr::mutate(
-      dplyr::across(
-        c(
-          .data[["original_admission_date"]],
-          .data[["rdd"]],
-          .data[["delay_end_date"]]
-        ),
-        lubridate::dmy
-      ),
       monthflag = lubridate::my(.data[["monthflag"]]),
       delay_end_reason = as.integer(.data[["delay_end_reason"]])
     ) %>%


### PR DESCRIPTION
Fixed a bug which caused the processed delayed discharges output to have 0 rows. The issue was that the raw extract had changed to date format for the key variables and our code was wanting to change this to dates causing the variables to return NA. This NA was passed through which could not be filtered on causing the drop.