### PR TITLE
Reduce the memory usage of the tests

### DIFF
--- a/R/calculate_measures.R
+++ b/R/calculate_measures.R
@@ -37,7 +37,7 @@ calculate_measures <- function(data,
 
   if (measure == "all") {
     data <- data %>%
-      dplyr::select(tidyselect::matches({{ vars }})) %>%
+      dplyr::select(tidyselect::contains({{ vars }})) %>%
       dplyr::summarise(
         dplyr::across(tidyselect::everything(),
           ~ sum(.x, na.rm = TRUE),
@@ -51,15 +51,17 @@ calculate_measures <- function(data,
       )
   } else if (measure == "sum") {
     data <- data %>%
-      dplyr::summarise(dplyr::across(
+      dplyr::summarise(
+        dplyr::across(
         tidyselect::everything(),
         ~ sum(.x, na.rm = TRUE)
       ))
   } else if (measure == "min-max") {
     data <- data %>%
-      dplyr::select(tidyselect::matches({{ vars }})) %>%
+      dplyr::select(tidyselect::contains({{ vars }})) %>%
       dplyr::summarise(
-        dplyr::across(tidyselect::everything(),
+        dplyr::across(
+          tidyselect::everything(),
           ~ min(.x, na.rm = TRUE),
           .names = "min_{col}"
         ),
@@ -69,8 +71,9 @@ calculate_measures <- function(data,
           .names = "max_{col}"
         )
       ) %>%
-      dplyr::mutate(dplyr::across(
-        where(lubridate::is.Date),
+      dplyr::mutate(
+        dplyr::across(
+        dplyr::where(lubridate::is.Date),
         ~ convert_date_to_numeric(.)
       ))
   }

--- a/R/calculate_measures.R
+++ b/R/calculate_measures.R
@@ -26,6 +26,8 @@ calculate_measures <- function(data,
   measure <- match.arg(measure)
 
   if (!is.null(group_by)) {
+    group_by <- match.arg(group_by, c("recid"))
+
     if (group_by == "recid") {
       data <- data %>%
         dplyr::group_by(.data$recid)

--- a/R/calculate_measures.R
+++ b/R/calculate_measures.R
@@ -53,9 +53,10 @@ calculate_measures <- function(data,
     data <- data %>%
       dplyr::summarise(
         dplyr::across(
-        tidyselect::everything(),
-        ~ sum(.x, na.rm = TRUE)
-      ))
+          tidyselect::everything(),
+          ~ sum(.x, na.rm = TRUE)
+        )
+      )
   } else if (measure == "min-max") {
     data <- data %>%
       dplyr::select(tidyselect::contains({{ vars }})) %>%
@@ -73,9 +74,10 @@ calculate_measures <- function(data,
       ) %>%
       dplyr::mutate(
         dplyr::across(
-        dplyr::where(lubridate::is.Date),
-        ~ convert_date_to_numeric(.)
-      ))
+          dplyr::where(lubridate::is.Date),
+          ~ convert_date_to_numeric(.)
+        )
+      )
   }
 
   if (!is.null(group_by)) {

--- a/R/convert_date_types.R
+++ b/R/convert_date_types.R
@@ -12,9 +12,7 @@
 #'
 #' @family date functions
 convert_date_to_numeric <- function(date) {
-  lubridate::year(date) * 10000L +
-    lubridate::month(date) * 100L +
-    lubridate::day(date)
+  as.integer(format(date, "%Y%m%d"))
 }
 
 #' Convert a date in 'SLF numeric format' to Date type

--- a/R/convert_date_types.R
+++ b/R/convert_date_types.R
@@ -29,5 +29,5 @@ convert_date_to_numeric <- function(date) {
 #'
 #' @family date functions
 convert_numeric_to_date <- function(numeric_date) {
-  as.Date(strptime(as.character(numeric_date), "%Y%m%d", tz = "UTC"))
+  as.Date(lubridate::fast_strptime(as.character(numeric_date), "%Y%m%d", tz = "UTC"))
 }

--- a/R/process_tests_episode_file.R
+++ b/R/process_tests_episode_file.R
@@ -12,17 +12,17 @@
 process_tests_episode_file <- function(data, year) {
   data <- data %>%
     dplyr::select(
-    "chi",
-    "gender",
-    "postcode",
-    "hbtreatcode",
-    "dob",
-    "recid",
-    "yearstay",
-    "record_keydate1",
-    "record_keydate2",
-    dplyr::contains(c("beddays", "cost", "cij"))
-  )
+      "chi",
+      "gender",
+      "postcode",
+      "hbtreatcode",
+      "dob",
+      "recid",
+      "yearstay",
+      "record_keydate1",
+      "record_keydate2",
+      dplyr::contains(c("beddays", "cost", "cij"))
+    )
 
   old_data <- get_existing_data_for_tests(data)
 

--- a/R/process_tests_episode_file.R
+++ b/R/process_tests_episode_file.R
@@ -10,6 +10,20 @@
 #'
 #' @export
 process_tests_episode_file <- function(data, year) {
+  data <- data %>%
+    dplyr::select(
+    "chi",
+    "gender",
+    "postcode",
+    "hbtreatcode",
+    "dob",
+    "recid",
+    "yearstay",
+    "record_keydate1",
+    "record_keydate2",
+    dplyr::contains(c("beddays", "cost", "cij"))
+  )
+
   old_data <- get_existing_data_for_tests(data)
 
   comparison <- produce_test_comparison(


### PR DESCRIPTION
The main saving here is for the episode file tests (the same improvements should be applied to the individual file tests). By only keeping the variables which are actually needed for the tests some memory is saved (~60%) but importantly we then only read those variables in from the 'existing' file which makes that part faster and also use less memory.

Other changes are minor and only speed things up in a small way.