### PR TITLE
Fixing some variables in the episode file

### DIFF
--- a/R/link_delayed_discharge_eps.R
+++ b/R/link_delayed_discharge_eps.R
@@ -289,7 +289,6 @@ link_delayed_discharge_eps <- function(data, year) {
       "lca" = "dd_responsible_lca",
       "hbtreatcode" = "hbtreatcode_dd",
       "original_admission_date",
-      "amended_dates",
       "delay_end_reason",
       "primary_delay_reason",
       "secondary_delay_reason",

--- a/R/run_episode_file.R
+++ b/R/run_episode_file.R
@@ -306,8 +306,22 @@ join_cohort_lookups <- function(ep_file_data, year) {
   )
 
   join_cohort_lookups <- ep_file_data %>%
-    dplyr::left_join(demographic_cohorts, by = "chi") %>%
-    dplyr::left_join(service_use_cohorts, by = "chi")
+  dplyr::left_join(
+    demographic_cohorts %>%
+      dplyr::select(
+        "chi",
+        "demographic_cohort"
+      ),
+    by = "chi"
+  ) %>%
+  dplyr::left_join(
+    service_use_cohorts %>%
+      dplyr::select(
+        "chi",
+        "service_use_cohort"
+      ),
+    by = "chi"
+  )
 
   return(join_cohort_lookups)
 }

--- a/R/run_episode_file.R
+++ b/R/run_episode_file.R
@@ -306,22 +306,22 @@ join_cohort_lookups <- function(ep_file_data, year) {
   )
 
   join_cohort_lookups <- ep_file_data %>%
-  dplyr::left_join(
-    demographic_cohorts %>%
-      dplyr::select(
-        "chi",
-        "demographic_cohort"
-      ),
-    by = "chi"
-  ) %>%
-  dplyr::left_join(
-    service_use_cohorts %>%
-      dplyr::select(
-        "chi",
-        "service_use_cohort"
-      ),
-    by = "chi"
-  )
+    dplyr::left_join(
+      demographic_cohorts %>%
+        dplyr::select(
+          "chi",
+          "demographic_cohort"
+        ),
+      by = "chi"
+    ) %>%
+    dplyr::left_join(
+      service_use_cohorts %>%
+        dplyr::select(
+          "chi",
+          "service_use_cohort"
+        ),
+      by = "chi"
+    )
 
   return(join_cohort_lookups)
 }

--- a/R/run_episode_file.R
+++ b/R/run_episode_file.R
@@ -24,6 +24,7 @@ run_episode_file <- function(processed_data_list, year, write_to_disk = TRUE) {
       "postcode",
       "hbrescode",
       "lca",
+      "location",
       "hbtreatcode",
       "ipdc",
       "spec",


### PR DESCRIPTION
Some variables were being duplicated by a `*_join`, me and @Jennit07 identified these:

- `location`, was being 'stored' but now it's used in the DD linkage part of the code
- `amended_dates`, was being kept from the DD data but isn't required as the data is encoded in `dd_quality`
- For the `service_use` and `demographic` cohorts, all the variables were being matched on but we only include the actual cohort variables in the SLF.