### PR TITLE
Rename `datazone` to `datazone2011`

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -88,6 +88,7 @@ hms
 homecare
 hscp
 hscpnames
+IDPC
 infyyear
 ipdc
 itle
@@ -100,6 +101,7 @@ keydate
 keyring
 keytime
 keytimex
+kis
 los
 ltc
 ltcs

--- a/R/fill_geographies.R
+++ b/R/fill_geographies.R
@@ -14,7 +14,7 @@ fill_geographies <- function(data) {
     "hbrescode",
     "hscp",
     "lca",
-    "datazone",
+    "datazone2011",
     "hbpraccode",
     "hbtreatcode",
     "gpprac"

--- a/R/process_extract_acute.R
+++ b/R/process_extract_acute.R
@@ -79,7 +79,7 @@ process_extract_acute <- function(data, year, write_to_disk = TRUE) {
       "hbrescode",
       "lca",
       "hscp",
-      "datazone",
+      "datazone2011",
       "location",
       "hbtreatcode",
       "yearstay",

--- a/R/process_extract_district_nursing.R
+++ b/R/process_extract_district_nursing.R
@@ -107,7 +107,7 @@ process_extract_district_nursing <- function(
           "gender",
           "gpprac",
           "postcode",
-          "datazone",
+          "datazone2011",
           "lca",
           "hscp",
           "hbrescode",

--- a/R/process_extract_gp_ooh.R
+++ b/R/process_extract_gp_ooh.R
@@ -111,7 +111,7 @@ process_extract_gp_ooh <- function(year, data_list, write_to_disk = TRUE) {
       "gpprac",
       "postcode",
       "hbrescode",
-      "datazone",
+      "datazone2011",
       "hscp",
       "hbtreatcode",
       "location",

--- a/R/process_extract_mental_health.R
+++ b/R/process_extract_mental_health.R
@@ -85,7 +85,7 @@ process_extract_mental_health <- function(data, year, write_to_disk = TRUE) {
       "hbrescode",
       "lca",
       "hscp",
-      "datazone",
+      "datazone2011",
       "location",
       "hbtreatcode",
       "stay",

--- a/R/read_extract_acute.R
+++ b/R/read_extract_acute.R
@@ -107,7 +107,7 @@ read_extract_acute <- function(year, file_path = get_boxi_extract_path(year = ye
       disch = "Discharge Type Code",
       falls_adm = "Falls Related Admission (01)",
       lca = "Geo Council Area Code",
-      datazone = "Geo Data Zone 2011",
+      datazone2011 = "Geo Data Zone 2011",
       postcode = "Geo Postcode [C]",
       hscp = "Geo HSCP of Residence Code - current",
       conc = "Lead Consultant/HCP Code",

--- a/R/read_extract_district_nursing.R
+++ b/R/read_extract_district_nursing.R
@@ -43,7 +43,7 @@ read_extract_district_nursing <- function(
       lca = "Patient Council Area Code (Contact)",
       postcode = "Patient Postcode [C] (Contact)",
       gpprac = "Practice Code (Contact)",
-      datazone = "Patient Data Zone 2011 (Contact)",
+      datazone2011 = "Patient Data Zone 2011 (Contact)",
       hbpraccode = "Practice NHS Board Code 9 (Contact)",
       hbtreatcode = "Treatment NHS Board Code 9",
       chi = "UPI Number [C]",

--- a/R/read_extract_mental_health.R
+++ b/R/read_extract_mental_health.R
@@ -83,7 +83,7 @@ read_extract_mental_health <- function(
       hbrescode = "NHS Board of Residence Code - current",
       lca = "Geo Council Area Code",
       hscp = "Geo HSCP of Residence Code - current",
-      datazone = "Geo Data Zone 2011",
+      datazone2011 = "Geo Data Zone 2011",
       location = "Treatment Location Code",
       hbtreatcode = "Treatment NHS Board Code - current",
       yearstay = "Occupied Bed Days (04)",

--- a/R/read_extract_nrs_deaths.R
+++ b/R/read_extract_nrs_deaths.R
@@ -39,7 +39,7 @@ read_extract_nrs_deaths <- function(
     dplyr::rename(
       death_location_code = "Death Location Code",
       lca = "Geo Council Area Code",
-      datazone = "Geo Data Zone 2011",
+      datazone2011 = "Geo Data Zone 2011",
       postcode = "Geo Postcode [C]",
       hscp = "Geo HSCP of Residence Code - current",
       death_board_occurrence = "NHS Board of Occurrence Code - current",

--- a/R/read_extract_ooh_consultations.R
+++ b/R/read_extract_ooh_consultations.R
@@ -34,7 +34,7 @@ read_extract_ooh_consultations <- function(
       postcode = "Patient Postcode [C]",
       hbrescode = "Patient NHS Board Code 9 - current",
       hscp = "HSCP of Residence Code Current",
-      datazone = "Patient Data Zone 2011",
+      datazone2011 = "Patient Data Zone 2011",
       gpprac = "Practice Code",
       ooh_case_id = "GUID",
       attendance_status = "Consultation Recorded",

--- a/R/run_episode_file.R
+++ b/R/run_episode_file.R
@@ -51,7 +51,7 @@ run_episode_file <- function(processed_data_list, year, write_to_disk = TRUE) {
         "cij_dis_spec",
         "cost_total_net",
         "hscp",
-        "datazone",
+        "datazone2011",
         "attendance_status",
         "deathdiag1",
         "deathdiag2",


### PR DESCRIPTION
Renaming of `datazone` to `datazone2011` in the `Read_xxx_extracts` and `process_xxx_extracts`. This will prevent the extra variable `datazone` appearing in the final episode and individual files. 