### PR TITLE
Fix for anon_chi missing

### DIFF
--- a/R/run_episode_file.R
+++ b/R/run_episode_file.R
@@ -110,11 +110,15 @@ run_episode_file <- function(
     load_ep_file_vars(year)
 
   if (anon_chi_out) {
-    episode_file <- slfhelper::get_anon_chi(
-      episode_file,
-      chi_var = "chi",
-      drop = TRUE
-    )
+    # TODO When slfhelper is update remove the unnecessary code
+    episode_file <- episode_file %>%
+      tidyr::replace_na(list(chi = "")) %>%
+      slfhelper::get_anon_chi(
+        episode_file,
+        chi_var = "chi",
+        drop = TRUE
+      ) %>%
+      dplyr::mutate(anon_chi = dplyr::na_if(.data$anon_chi, ""))
   }
 
   if (write_to_disk) {

--- a/R/run_episode_file.R
+++ b/R/run_episode_file.R
@@ -86,7 +86,7 @@ run_episode_file <- function(
       )
     ) %>%
     # Check chi is valid using phsmethods function
-    # If the CHI is invalid for whatever reason, set the CHI to blank string
+    # If the CHI is invalid for whatever reason, set the CHI to NA
     dplyr::mutate(
       chi = dplyr::if_else(
         phsmethods::chi_check(.data$chi) != "Valid CHI",
@@ -110,14 +110,10 @@ run_episode_file <- function(
     load_ep_file_vars(year)
 
   if (anon_chi_out) {
-    # TODO When slfhelper is update remove the unnecessary code
+    # TODO When slfhelper is updated remove the unnecessary code
     episode_file <- episode_file %>%
       tidyr::replace_na(list(chi = "")) %>%
-      slfhelper::get_anon_chi(
-        episode_file,
-        chi_var = "chi",
-        drop = TRUE
-      ) %>%
+      slfhelper::get_anon_chi() %>%
       dplyr::mutate(anon_chi = dplyr::na_if(.data$anon_chi, ""))
   }
 
@@ -139,10 +135,10 @@ run_episode_file <- function(
 
 #' Store the unneeded episode file variables
 #'
-#' @param data The in progress episode file data.
+#' @param data The in-progress episode file data.
 #' @inheritParams run_episode_file
-#' @param vars_to_keep a character vector of variable to keep, all others will
-#' be stored.
+#' @param vars_to_keep a character vector of the variables to keep, all others 
+#' will be stored.
 #'
 #' @return `data` with only the `vars_to_keep` kept
 store_ep_file_vars <- function(data, year, vars_to_keep) {
@@ -328,7 +324,7 @@ create_cost_inc_dna <- function(data) {
 #'
 #' @return The data unchanged (the cohorts are written to disk)
 create_cohort_lookups <- function(data, year, update = latest_update()) {
-  # Use future so the cohorts can be create simultaneously (in parallel)
+  # Use future so the cohorts can be created simultaneously (in parallel)
   future::plan(strategy = future.callr::callr, .skip = TRUE)
   options(future.globals.maxSize = 21474836480)
 

--- a/R/run_episode_file.R
+++ b/R/run_episode_file.R
@@ -137,7 +137,7 @@ run_episode_file <- function(
 #'
 #' @param data The in-progress episode file data.
 #' @inheritParams run_episode_file
-#' @param vars_to_keep a character vector of the variables to keep, all others 
+#' @param vars_to_keep a character vector of the variables to keep, all others
 #' will be stored.
 #'
 #' @return `data` with only the `vars_to_keep` kept

--- a/man/correct_cij_vars.Rd
+++ b/man/correct_cij_vars.Rd
@@ -7,7 +7,7 @@
 correct_cij_vars(data)
 }
 \arguments{
-\item{data}{The in progress episode file data.}
+\item{data}{The in-progress episode file data.}
 }
 \value{
 The data with CIJ variables corrected.

--- a/man/create_cohort_lookups.Rd
+++ b/man/create_cohort_lookups.Rd
@@ -7,7 +7,7 @@
 create_cohort_lookups(data, year, update = latest_update())
 }
 \arguments{
-\item{data}{The in progress episode file data.}
+\item{data}{The in-progress episode file data.}
 
 \item{year}{The year to process, in FY format.}
 

--- a/man/create_cost_inc_dna.Rd
+++ b/man/create_cost_inc_dna.Rd
@@ -7,7 +7,7 @@
 create_cost_inc_dna(data)
 }
 \arguments{
-\item{data}{The in progress episode file data.}
+\item{data}{The in-progress episode file data.}
 }
 \value{
 The data with cost including dna.

--- a/man/fill_missing_cij_markers.Rd
+++ b/man/fill_missing_cij_markers.Rd
@@ -7,7 +7,7 @@
 fill_missing_cij_markers(data)
 }
 \arguments{
-\item{data}{The in progress episode file data.}
+\item{data}{The in-progress episode file data.}
 }
 \value{
 A data frame with CIJ markers filled in for those missing.

--- a/man/join_cohort_lookups.Rd
+++ b/man/join_cohort_lookups.Rd
@@ -7,7 +7,7 @@
 join_cohort_lookups(data, year, update = latest_update())
 }
 \arguments{
-\item{data}{The in progress episode file data.}
+\item{data}{The in-progress episode file data.}
 
 \item{year}{The year to process, in FY format.}
 

--- a/man/join_sparra_hhg.Rd
+++ b/man/join_sparra_hhg.Rd
@@ -7,7 +7,7 @@
 join_sparra_hhg(data, year)
 }
 \arguments{
-\item{data}{The in progress episode file data.}
+\item{data}{The in-progress episode file data.}
 
 \item{year}{The year to process, in FY format.}
 }

--- a/man/load_ep_file_vars.Rd
+++ b/man/load_ep_file_vars.Rd
@@ -7,7 +7,7 @@
 load_ep_file_vars(data, year)
 }
 \arguments{
-\item{data}{The in progress episode file data.}
+\item{data}{The in-progress episode file data.}
 
 \item{year}{The year to process, in FY format.}
 }

--- a/man/store_ep_file_vars.Rd
+++ b/man/store_ep_file_vars.Rd
@@ -7,12 +7,12 @@
 store_ep_file_vars(data, year, vars_to_keep)
 }
 \arguments{
-\item{data}{The in progress episode file data.}
+\item{data}{The in-progress episode file data.}
 
 \item{year}{The year to process, in FY format.}
 
-\item{vars_to_keep}{a character vector of variable to keep, all others will
-be stored.}
+\item{vars_to_keep}{a character vector of the variables to keep, all others
+will be stored.}
 }
 \value{
 \code{data} with only the \code{vars_to_keep} kept


### PR DESCRIPTION
`slfhelper::get_anon_chi` converts `NA` to "TkE=" which would then be converted back to "e1" 🤯

This fixes that by making NA CHIs blank `""`, then making blank anon_chis NA after.

slfhelper should be updated so that it always converts NA to NA.