### PR TITLE
Investigate missing datazone from episode file

### DIFF
--- a/R/process_extract_ae.R
+++ b/R/process_extract_ae.R
@@ -35,6 +35,10 @@ process_extract_ae <- function(data, year, write_to_disk = TRUE) {
       .data$postcode_chi,
       .data$postcode_epi
     )) %>%
+    # Use phs methods to format postcode in pc7
+    dplyr::mutate(
+      postcode = phsmethods::format_postcode(.data$postcode, "pc7")
+    ) %>%
     ## recode cypher HB codes ##
     dplyr::mutate(
       dplyr::across(c("hbtreatcode", "hbrescode"), ~ dplyr::case_when(

--- a/_targets.R
+++ b/_targets.R
@@ -562,7 +562,7 @@ list(
         data = individual_file,
         year = year
       )
-    )#,
+    ) # ,
     # tar_target(
     #   episode_file_dataset,
     #   arrow::write_dataset(


### PR DESCRIPTION
Good spot from @shintoLamp where datazone was missing from A&E data (~38% of records). I have found the cause of this to be A&E data using `pc8` format in the postcode which later tries to match to the SLF postcode lookup which is in `pc7` format. I have tested this using `phs_methods::format_postcode` within the `process_extract_ae` and this appears to correct this where ~2% of A&E records are now with a missing datazone. 

I wonder if it is worth implementing this somewhere in the `run_episode_file` pipeline as a 'catch all' to ensure we are using pc7 everywhere? what are our thoughts on this? Thanks