### PR TITLE
Bug - Outpatients tests failing due to missing HSCP

### DIFF
--- a/R/process_tests_outpatients.R
+++ b/R/process_tests_outpatients.R
@@ -13,12 +13,12 @@ process_tests_outpatients <- function(data, year) {
     old_data = produce_source_extract_tests(old_data,
       sum_mean_vars = "cost",
       max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net"),
-      hscp_var = FALSE
+      add_hscp_count = FALSE
     ),
     new_data = produce_source_extract_tests(data,
       sum_mean_vars = "cost",
       max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net"),
-      hscp_var = FALSE
+      add_hscp_count = FALSE
     )
   ) %>%
     write_tests_xlsx(sheet_name = "00B", year)

--- a/R/process_tests_outpatients.R
+++ b/R/process_tests_outpatients.R
@@ -12,11 +12,13 @@ process_tests_outpatients <- function(data, year) {
   comparison <- produce_test_comparison(
     old_data = produce_source_extract_tests(old_data,
       sum_mean_vars = "cost",
-      max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net")
+      max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net"),
+      hscp_var = FALSE
     ),
     new_data = produce_source_extract_tests(data,
       sum_mean_vars = "cost",
-      max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net")
+      max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net"),
+      hscp_var = FALSE
     )
   ) %>%
     write_tests_xlsx(sheet_name = "00B", year)

--- a/R/produce_source_extract_tests.R
+++ b/R/produce_source_extract_tests.R
@@ -13,6 +13,7 @@
 #' (data is from [get_source_extract_path()])
 #' @param sum_mean_vars variables used when selecting 'all' measures from [calculate_measures()]
 #' @param max_min_vars variables used when selecting 'min-max' from [calculate_measures()]
+#' @param hscp_var Default set to TRUE. For use where `hscp variable` is not available, specify FALSE.
 #'
 #' @return a dataframe with a count of each flag
 #' from [calculate_measures()]
@@ -28,13 +29,22 @@ produce_source_extract_tests <- function(data,
                                          max_min_vars = c(
                                            "record_keydate1", "record_keydate2",
                                            "cost_total_net", "yearstay"
-                                         )) {
+                                         ),
+                                         hscp_var = TRUE) {
   test_flags <- data %>%
     # use functions to create HB and partnership flags
     create_demog_test_flags() %>%
     create_hb_test_flags(.data$hbtreatcode) %>%
-    create_hb_cost_test_flags(.data$hbtreatcode, .data$cost_total_net) %>%
-    create_hscp_test_flags(.data$hscp) %>%
+    create_hb_cost_test_flags(.data$hbtreatcode, .data$cost_total_net)
+
+  if (!hscp_var) {
+    test_flags <- test_flags
+  } else {
+    test_flags %>%
+      create_hscp_test_flags(.data$hscp)
+  }
+
+  test_flags <- test_flags %>%
     # keep variables for comparison
     dplyr::select("valid_chi":dplyr::last_col()) %>%
     # use function to sum new test flags

--- a/R/produce_source_extract_tests.R
+++ b/R/produce_source_extract_tests.R
@@ -30,18 +30,15 @@ produce_source_extract_tests <- function(data,
                                            "record_keydate1", "record_keydate2",
                                            "cost_total_net", "yearstay"
                                          ),
-                                         hscp_var = TRUE) {
+                                         add_hscp_count = TRUE) {
   test_flags <- data %>%
     # use functions to create HB and partnership flags
     create_demog_test_flags() %>%
     create_hb_test_flags(.data$hbtreatcode) %>%
     create_hb_cost_test_flags(.data$hbtreatcode, .data$cost_total_net)
 
-  if (!hscp_var) {
-    test_flags <- test_flags
-  } else {
-    test_flags %>%
-      create_hscp_test_flags(.data$hscp)
+  if (add_hscp_count) {
+    test_flags <- create_hscp_test_flags(test_flags, .data$hscp)
   }
 
   test_flags <- test_flags %>%

--- a/R/produce_source_extract_tests.R
+++ b/R/produce_source_extract_tests.R
@@ -13,7 +13,7 @@
 #' (data is from [get_source_extract_path()])
 #' @param sum_mean_vars variables used when selecting 'all' measures from [calculate_measures()]
 #' @param max_min_vars variables used when selecting 'min-max' from [calculate_measures()]
-#' @param hscp_var Default set to TRUE. For use where `hscp variable` is not available, specify FALSE.
+#' @param add_hscp_count  Default set to TRUE. For use where `hscp variable` is not available, specify FALSE.
 #'
 #' @return a dataframe with a count of each flag
 #' from [calculate_measures()]

--- a/_SPSS_archived/All_years/02-Lookups/99_extract_NSU_data.R
+++ b/_SPSS_archived/All_years/02-Lookups/99_extract_NSU_data.R
@@ -42,4 +42,4 @@ if (file_exists(file_path)) {
 }
 
 nsu_data %>%
-arrow::write_parquet(file_path, compression = "zstd", compression_level = 10)
+  arrow::write_parquet(file_path, compression = "zstd", compression_level = 10)

--- a/_SPSS_archived/All_years/02-Lookups/99_extract_NSU_data.R
+++ b/_SPSS_archived/All_years/02-Lookups/99_extract_NSU_data.R
@@ -42,4 +42,4 @@ if (file_exists(file_path)) {
 }
 
 nsu_data %>%
-  arrow::write_parquet(file_path, compression = "zstd", compression_level = 10)
+arrow::write_parquet(file_path, compression = "zstd", compression_level = 10)

--- a/man/produce_source_extract_tests.Rd
+++ b/man/produce_source_extract_tests.Rd
@@ -7,7 +7,8 @@
 produce_source_extract_tests(
   data,
   sum_mean_vars = c("beddays", "cost", "yearstay"),
-  max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net", "yearstay")
+  max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net", "yearstay"),
+  hscp_var = TRUE
 )
 }
 \arguments{
@@ -17,6 +18,8 @@ produce_source_extract_tests(
 \item{sum_mean_vars}{variables used when selecting 'all' measures from \code{\link[=calculate_measures]{calculate_measures()}}}
 
 \item{max_min_vars}{variables used when selecting 'min-max' from \code{\link[=calculate_measures]{calculate_measures()}}}
+
+\item{hscp_var}{Default set to TRUE. For use where \verb{hscp variable} is not available, specify FALSE.}
 }
 \value{
 a dataframe with a count of each flag

--- a/man/produce_source_extract_tests.Rd
+++ b/man/produce_source_extract_tests.Rd
@@ -19,7 +19,7 @@ produce_source_extract_tests(
 
 \item{max_min_vars}{variables used when selecting 'min-max' from \code{\link[=calculate_measures]{calculate_measures()}}}
 
-\item{hscp_var}{Default set to TRUE. For use where \verb{hscp variable} is not available, specify FALSE.}
+\item{add_hscp_count}{Default set to TRUE. For use where \verb{hscp variable} is not available, specify FALSE.}
 }
 \value{
 a dataframe with a count of each flag

--- a/man/produce_source_extract_tests.Rd
+++ b/man/produce_source_extract_tests.Rd
@@ -8,7 +8,7 @@ produce_source_extract_tests(
   data,
   sum_mean_vars = c("beddays", "cost", "yearstay"),
   max_min_vars = c("record_keydate1", "record_keydate2", "cost_total_net", "yearstay"),
-  hscp_var = TRUE
+  add_hscp_count = TRUE
 )
 }
 \arguments{
@@ -19,7 +19,7 @@ produce_source_extract_tests(
 
 \item{max_min_vars}{variables used when selecting 'min-max' from \code{\link[=calculate_measures]{calculate_measures()}}}
 
-\item{hscp_var}{Default set to TRUE. For use where \verb{hscp variable} is not available, specify FALSE.}
+\item{add_hscp_count}{Default set to TRUE. For use where \verb{hscp variable} is not available, specify FALSE.}
 }
 \value{
 a dataframe with a count of each flag

--- a/man/produce_source_extract_tests.Rd
+++ b/man/produce_source_extract_tests.Rd
@@ -19,7 +19,7 @@ produce_source_extract_tests(
 
 \item{max_min_vars}{variables used when selecting 'min-max' from \code{\link[=calculate_measures]{calculate_measures()}}}
 
-\item{add_hscp_count}{Default set to TRUE. For use where \verb{hscp variable} is not available, specify FALSE.}
+\item{hscp_var}{Default set to TRUE. For use where \verb{hscp variable} is not available, specify FALSE.}
 }
 \value{
 a dataframe with a count of each flag


### PR DESCRIPTION
@Moohan identified an issue in targets where the outpatients tests were failing due to a missing HSCP. In the outpatients extract, there is no hscp variable, therefore i've added a parameter to the 'general' tests function which is applied to costs extracts. 

The function is set up so that HSCP should only be `FALSE` in instances where there is no HSCP variable available. I can't think of any other places this may be the case but we have this as an option if needed. 