### PR TITLE
BUG - Fix for the episode file tests

### DIFF
--- a/R/get_existing_data_for_tests.R
+++ b/R/get_existing_data_for_tests.R
@@ -58,5 +58,5 @@ get_existing_data_for_tests <- function(new_data, file_version = "episode") {
     ))
   }
 
-  return(slfhelper::get_chi(slf_data))
+  return(slf_data)
 }

--- a/R/process_tests_episode_file.R
+++ b/R/process_tests_episode_file.R
@@ -20,8 +20,7 @@ process_tests_episode_file <- function(data, year) {
       "record_keydate1",
       "record_keydate2",
       dplyr::contains(c("beddays", "cost", "cij"))
-    ) %>%
-    slfhelper::get_chi()
+    )
 
   old_data <- get_existing_data_for_tests(data)
 

--- a/R/process_tests_episode_file.R
+++ b/R/process_tests_episode_file.R
@@ -104,9 +104,15 @@ produce_episode_file_tests <- function(
         1L,
         0L
       )
-    ) %>%
+    )
+
+  if (!recid == "00B") {
+    test_flags <- create_hscp_test_flags(test_flags, .data$hscp2018)
+  }
+
+  test_flags <- test_flags %>%
     # keep variables for comparison
-    dplyr::select("valid_chi":dplyr::last_col()) %>%
+    dplyr::select("unique_anon_chi":dplyr::last_col()) %>%
     # use function to sum new test flags
     calculate_measures(measure = "sum", group_by = "recid")
 

--- a/R/process_tests_episode_file.R
+++ b/R/process_tests_episode_file.R
@@ -71,10 +71,17 @@ produce_episode_file_tests <- function(
   test_flags <- data %>%
     dplyr::group_by(.data$recid) %>%
     # use functions to create HB and partnership flags
-    create_demog_test_flags() %>%
+    dplyr::mutate(
+      unique_anon_chi = dplyr::lag(.data$anon_chi) != .data$anon_chi,
+      n_missing_anon_chi = is_missing(.data$anon_chi),
+      n_males = .data$gender == 1L,
+      n_females = .data$gender == 2L,
+      n_postcode = !is.na(.data$postcode) | !.data$postcode == "",
+      n_missing_postcode = is_missing(.data$postcode),
+      missing_dob = is.na(.data$dob)
+    ) %>%
     create_hb_test_flags(.data$hbtreatcode) %>%
     create_hb_cost_test_flags(.data$hbtreatcode, .data$cost_total_net) %>%
-    create_hscp_test_flags(.data$hscp2018) %>%
     # Flags to count stay types
     dplyr::mutate(
       cij_elective = dplyr::if_else(

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -14,7 +14,7 @@ read_file(path, col_select = NULL, as_data_frame = TRUE, ...)
 \link[tidyselect:eval_select]{tidy selection specification}
 of columns, as used in \code{dplyr::select()}.}
 
-\item{as_data_frame}{Should the function return a \code{data.frame} (default) or
+\item{as_data_frame}{Should the function return a \code{tibble} (default) or
 an Arrow \link[arrow]{Table}?}
 
 \item{...}{Addition arguments passed to the relevant function.}


### PR DESCRIPTION
The episode file tests were taking far too long to process the tests due to `slfhelper::get_chi()`. I have changed the tests to check for `anon_chi` instead of `chi`. This will show how many unique `anon_chi` we have and how many missing. The only difference from the `chi` checks before is that we cant test for `valid chi` using `phs_methods::`. I have tested this against 1718 and it is able to produce the tests. 

Once this has merged back in we will be able to run targets again as due to tests failing this was unable to create the individual file. 