### PR TITLE
Add condition for latest file where no social care data is available

### DIFF
--- a/R/add_hri_variables.R
+++ b/R/add_hri_variables.R
@@ -71,7 +71,7 @@ add_hri_variables <- function(
   hri_lookup <- data %>%
     dplyr::select(
       "year",
-      "chi",
+      chi_variable,
       "postcode",
       "gpprac",
       "lca",

--- a/R/aggregate_by_chi.R
+++ b/R/aggregate_by_chi.R
@@ -258,13 +258,13 @@ aggregate_by_chi_no_sc <- function(episode_file) {
   data.table::setnames(
     episode_file,
     c(
-      #"ch_chi_cis",
+      # "ch_chi_cis",
       "cij_marker",
       "ooh_case_id",
       "hh_in_fy"
     ),
     c(
-      #"ch_cis_episodes",
+      # "ch_cis_episodes",
       "cij_total",
       "ooh_cases",
       "hl1_in_fy"
@@ -276,12 +276,12 @@ aggregate_by_chi_no_sc <- function(episode_file) {
   cols2 <- c(
     "postcode",
     "dob",
-    "gpprac"#,
-    #vars_start_with(episode_file, "sc_")
+    "gpprac" # ,
+    # vars_start_with(episode_file, "sc_")
   )
   # columns to count unique rows
   cols3 <- c(
-    #"ch_cis_episodes",
+    # "ch_cis_episodes",
     "cij_total",
     "cij_el",
     "cij_non_el",
@@ -302,8 +302,8 @@ aggregate_by_chi_no_sc <- function(episode_file) {
         "attend",
         "contacts",
         "hours",
-        #"alarms",
-        #"telecare",
+        # "alarms",
+        # "telecare",
         "paid_items",
         "advice",
         "homev",
@@ -313,63 +313,63 @@ aggregate_by_chi_no_sc <- function(episode_file) {
         "dn",
         "nhs24",
         "pcc"
-      #)
-    ),
-    #vars_start_with(
-      #episode_file,
-      #"sds_option"
+        # )
+      ),
+      # vars_start_with(
+      # episode_file,
+      # "sds_option"
     ),
     "health_net_cost_inc_dnas"
   )
-  #cols4 <- cols4[!(cols4 %in% "ch_cis_episodes")]
+  # cols4 <- cols4[!(cols4 %in% "ch_cis_episodes")]
   # columns to select maximum
   cols5 <- c("nsu", vars_contain(episode_file, "hl1_in_fy"))
   data.table::setnafill(episode_file, fill = 0L, cols = cols5)
   # compute
   individual_file_cols1 <- episode_file[,
-                                        .(gender = mean(gender)),
-                                        by = "chi"
+    .(gender = mean(gender)),
+    by = "chi"
   ]
   individual_file_cols2 <- episode_file[,
-                                        .SD[.N],
-                                        .SDcols = cols2,
-                                        by = "chi"
+    .SD[.N],
+    .SDcols = cols2,
+    by = "chi"
   ]
   individual_file_cols3 <- episode_file[,
-                                        lapply(.SD, function(x) {
-                                          data.table::uniqueN(x, na.rm = TRUE)
-                                        }),
-                                        .SDcols = cols3,
-                                        by = "chi"
+    lapply(.SD, function(x) {
+      data.table::uniqueN(x, na.rm = TRUE)
+    }),
+    .SDcols = cols3,
+    by = "chi"
   ]
   individual_file_cols4 <- episode_file[,
-                                        lapply(.SD, function(x) {
-                                          sum(x, na.rm = TRUE)
-                                        }),
-                                        .SDcols = cols4,
-                                        by = "chi"
+    lapply(.SD, function(x) {
+      sum(x, na.rm = TRUE)
+    }),
+    .SDcols = cols4,
+    by = "chi"
   ]
   individual_file_cols5 <- episode_file[,
-                                        lapply(.SD, function(x) max(x, na.rm = TRUE)),
-                                        .SDcols = cols5,
-                                        by = "chi"
+    lapply(.SD, function(x) max(x, na.rm = TRUE)),
+    .SDcols = cols5,
+    by = "chi"
   ]
   individual_file_cols6 <- episode_file[,
-                                        .(
-                                          preventable_beddays = ifelse(
-                                            any(cij_ppa, na.rm = TRUE),
-                                            as.integer(min(cij_end_date, end_fy(year)) - max(cij_start_date, start_fy(year))),
-                                            NA_integer_
-                                          )
-                                        ),
-                                        # cij_marker has been renamed as cij_total
-                                        by = c("chi", "cij_total")
+    .(
+      preventable_beddays = ifelse(
+        any(cij_ppa, na.rm = TRUE),
+        as.integer(min(cij_end_date, end_fy(year)) - max(cij_start_date, start_fy(year))),
+        NA_integer_
+      )
+    ),
+    # cij_marker has been renamed as cij_total
+    by = c("chi", "cij_total")
   ]
   individual_file_cols6 <- individual_file_cols6[,
-                                                 .(
-                                                   preventable_beddays = sum(preventable_beddays, na.rm = TRUE)
-                                                 ),
-                                                 by = "chi"
+    .(
+      preventable_beddays = sum(preventable_beddays, na.rm = TRUE)
+    ),
+    by = "chi"
   ]
 
   individual_file <- dplyr::bind_cols(

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -173,7 +173,7 @@ add_cij_columns <- function(episode_file) {
 add_all_columns <- function(episode_file) {
   cli::cli_alert_info("Add all columns function started at {Sys.time()}")
 
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_acute_columns("Acute", (.data$smrtype == "Acute-DC" | .data$smrtype == "Acute-IP") & .data$cij_pattype != "Maternity") %>%
     add_mat_columns("Mat", .data$recid == "02B" | .data$cij_pattype == "Maternity") %>%
     add_mh_columns("MH", .data$recid == "04B" & .data$cij_pattype != "Maternity") %>%
@@ -187,11 +187,17 @@ add_all_columns <- function(episode_file) {
     add_dd_columns("DD", .data$recid == "DD") %>%
     add_nsu_columns("NSU", .data$recid == "NSU") %>%
     add_nrs_columns("NRS", .data$recid == "NRS") %>%
-    add_hl1_columns("HL1", .data$recid == "HL1") %>%
-    add_ch_columns("CH", .data$recid == "CH") %>%
-    add_hc_columns("HC", .data$recid == "HC") %>%
-    add_at_columns("AT", .data$recid == "AT") %>%
-    add_sds_columns("SDS", .data$recid == "SDS") %>%
+    add_hl1_columns("HL1", .data$recid == "HL1")
+
+  if (check_year_valid(year, type = c("CH", "HC", "AT", "SDS"))) {
+    episode_file <- episode_file %>%
+      add_ch_columns("CH", .data$recid == "CH") %>%
+      add_hc_columns("HC", .data$recid == "HC") %>%
+      add_at_columns("AT", .data$recid == "AT") %>%
+      add_sds_columns("SDS", .data$recid == "SDS")
+  }
+
+  episode_file <- episode_file %>%
     dplyr::mutate(
       health_net_cost = rowSums(
         dplyr::pick(

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -100,9 +100,9 @@ create_individual_file <- function(
   if (!check_year_valid(year, type = c("CH", "HC", "AT", "SDS"))) {
     individual_file <- individual_file %>%
       dplyr::mutate(
-        CH_cis_episodes = NA,
-        CH_beddays = NA,
-        CH_cost = NA,
+        ch_cis_episodes = NA,
+        ch_beddays = NA,
+        ch_cost = NA,
         hc_episodes = NA,
         hc_personal_episodes = NA,
         hc_non_personal_episodes = NA,
@@ -112,12 +112,17 @@ create_individual_file <- function(
         hc_personal_hours = NA,
         hc_non_personal_hours = NA,
         hc_reablement_hours = NA,
-        AT_alarms = NA,
-        AT_telecare = NA,
-        SDS_option_1 = NA,
-        SDS_option_2 = NA,
-        SDS_option_3 = NA,
-        SDS_option_4 = NA
+        at_alarms = NA,
+        at_telecare = NA,
+        sds_option_1 = NA,
+        sds_option_2 = NA,
+        sds_option_3 = NA,
+        sds_option_4 = NA,
+        sc_living_alone = NA,
+        sc_support_from_unpaid_carer = NA,
+        sc_social_worker = NA,
+        sc_meals = NA,
+        sc_day_care = NA
       )
   }
 

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -88,7 +88,29 @@ create_individual_file <- function(
     dplyr::mutate(year = year, .before = dplyr::everything()) %>%
     add_hri_variables(chi_variable = "chi")
 
-
+  if (!check_year_valid(year, type = c("CH", "HC", "AT", "SDS"))) {
+    individual_file <- individual_file %>%
+      dplyr::mutate(
+        CH_cis_episodes = NA,
+        CH_beddays = NA,
+        CH_cost = NA,
+        hc_episodes = NA,
+        hc_personal_episodes = NA,
+        hc_non_personal_episodes = NA,
+        hc_reablement_episodes = NA,
+        hc_total_cost = NA,
+        hc_total_hours = NA,
+        hc_personal_hours = NA,
+        hc_non_personal_hours = NA,
+        hc_reablement_hours = NA,
+        AT_alarms = NA,
+        AT_telecare = NA,
+        SDS_option_1 = NA,
+        SDS_option_2 = NA,
+        SDS_option_3 = NA,
+        SDS_option_4 = NA
+      )
+  }
 
   if (anon_chi_out) {
     individual_file <- individual_file %>%

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -94,7 +94,7 @@ create_individual_file <- function(
     join_deaths_data(year) %>%
     join_sparra_hhg(year) %>%
     join_slf_lookup_vars() %>%
-    dplyr::mutate(year = year, .before = dplyr::everything()) %>%
+    dplyr::mutate(year = year) %>%
     add_hri_variables(chi_variable = "chi")
 
   if (!check_year_valid(year, type = c("CH", "HC", "AT", "SDS"))) {

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -74,15 +74,19 @@ create_individual_file <- function(
     add_cij_columns() %>%
     add_all_columns()
 
-  if (check_year_valid(year, type = c("CH", "HC", "AT", "SDS"))) {
+  if (!check_year_valid(year, type = c("CH", "HC", "AT", "SDS"))) {
     individual_file <- individual_file %>%
-      aggregate_ch_episodes()
+      aggregate_by_chi_no_sc()
+  } else {
+    individual_file <- individual_file %>%
+      aggregate_ch_episodes() %>%
+      clean_up_ch(year) %>%
+      aggregate_by_chi() %>%
+      join_sc_client(year)
   }
 
   individual_file <- individual_file %>%
-    clean_up_ch(year) %>%
     recode_gender() %>%
-    aggregate_by_chi() %>%
     clean_individual_file(year) %>%
     join_cohort_lookups(year) %>%
     add_homelessness_flag(year, lookup = homelessness_lookup) %>%
@@ -90,7 +94,6 @@ create_individual_file <- function(
     join_deaths_data(year) %>%
     join_sparra_hhg(year) %>%
     join_slf_lookup_vars() %>%
-    join_sc_client(year) %>%
     dplyr::mutate(year = year, .before = dplyr::everything()) %>%
     add_hri_variables(chi_variable = "chi")
 

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -72,8 +72,14 @@ create_individual_file <- function(
     ))) %>%
     remove_blank_chi() %>%
     add_cij_columns() %>%
-    add_all_columns() %>%
-    aggregate_ch_episodes() %>%
+    add_all_columns()
+
+  if (check_year_valid(year, type = c("CH", "HC", "AT", "SDS"))) {
+    individual_file <- individual_file %>%
+      aggregate_ch_episodes()
+  }
+
+  individual_file <- individual_file %>%
     clean_up_ch(year) %>%
     recode_gender() %>%
     aggregate_by_chi() %>%

--- a/R/run_episode_file.R
+++ b/R/run_episode_file.R
@@ -115,6 +115,38 @@ run_episode_file <- function(
     join_deaths_data(year) %>%
     load_ep_file_vars(year)
 
+  if (!check_year_valid(year, type = c("CH", "HC", "AT", "SDS"))) {
+    episode_file <- episode_file %>%
+      dplyr::mutate(
+        sc_send_lca = NA,
+        sc_living_alone = NA,
+        sc_support_from_unpaid_carer = NA,
+        sc_social_worker = NA,
+        sc_type_of_housing = NA,
+        sc_meals = NA,
+        sc_day_care = NA,
+        sc_latest_submission = NA,
+        ch_chi_cis = NA,
+        sc_id_cis = NA,
+        ch_name = NA,
+        ch_adm_reason = NA,
+        ch_provider = NA,
+        ch_nursing = NA,
+        hc_hours_annual = NA,
+        hc_hours_q1 = NA,
+        hc_hours_q2 = NA,
+        hc_hours_q3 = NA,
+        hc_hours_q4 = NA,
+        hc_cost_q1 = NA,
+        hc_cost_q2 = NA,
+        hc_cost_q3 = NA,
+        hc_cost_q4 = NA,
+        hc_provider = NA,
+        hc_reablement = NA,
+        sds_option_4 = NA,
+      )
+  }
+
   if (anon_chi_out) {
     episode_file <- slfhelper::get_anon_chi(episode_file)
   }


### PR DESCRIPTION
There was trouble creating the individual file due to social care variables not existing. This should now be declared in the episode file and passed to the individual file. In addition there are social care variables created by the individual file which are declared at the end of creating the individual file.

I have added conditions for running the code passed the aggregate section which require social care variables and this should now run if social care variables do exist or they do not.