### PR TITLE
transform the python script for sorting BI extracts to R

### DIFF
--- a/00_Sort_BI_Extracts.R
+++ b/00_Sort_BI_Extracts.R
@@ -1,5 +1,5 @@
 # Define the source directory and financial year pattern
-compress_files = FALSE
+compress_files <- FALSE
 source_dir <- "/conf/sourcedev/Source_Linkage_File_Updates/Extracts Temp"
 pattern <- "-20(\\d{4})\\.csv"
 
@@ -13,7 +13,7 @@ print(stringr::str_glue("Found {length(csv_files)} csv files to process."))
 extract_financial_year <- function(filename) {
   match <- regexpr(pattern, basename(filename))
   if (match[[1]][1] > 0) {
-    financial_year <- substr(basename(filename), match[[1]][1]+3, match[[1]][1] + 6)
+    financial_year <- substr(basename(filename), match[[1]][1] + 3, match[[1]][1] + 6)
     return(financial_year)
   } else {
     return(NULL)
@@ -32,8 +32,8 @@ for (csv_file in csv_files) {
     }
 
     # compress file
-    if(compress_files){
-      cat("Compressing:", basename(csv_file),"\n")
+    if (compress_files) {
+      cat("Compressing:", basename(csv_file), "\n")
       system2(
         command = "gzip",
         args = shQuote(csv_file)

--- a/00_Sort_BI_Extracts.R
+++ b/00_Sort_BI_Extracts.R
@@ -1,0 +1,50 @@
+# Define the source directory and financial year pattern
+compress_files = FALSE
+source_dir <- "/conf/sourcedev/Source_Linkage_File_Updates/Extracts Temp"
+pattern <- "-20(\\d{4})\\.csv"
+
+
+# List all the CSV files in the source directory
+cat(stringr::str_glue("Looking in '{source_dir}' for csv files."))
+csv_files <- list.files(source_dir, pattern = ".csv", full.names = TRUE)
+print(stringr::str_glue("Found {length(csv_files)} csv files to process."))
+
+# Create a function to extract the financial year from a filename
+extract_financial_year <- function(filename) {
+  match <- regexpr(pattern, basename(filename))
+  if (match[[1]][1] > 0) {
+    financial_year <- substr(basename(filename), match[[1]][1]+3, match[[1]][1] + 6)
+    return(financial_year)
+  } else {
+    return(NULL)
+  }
+}
+
+# Create directories for each financial year and move files
+for (csv_file in csv_files) {
+  financial_year <- extract_financial_year(csv_file)
+  # check if year directory exists
+  if (!is.null(financial_year)) {
+    financial_year_dir <- file.path("/conf/sourcedev/Source_Linkage_File_Updates", financial_year, "Extracts")
+    # if not, create the year directory
+    if (!dir.exists(financial_year_dir)) {
+      dir.create(financial_year_dir)
+    }
+
+    # compress file
+    if(compress_files){
+      cat("Compressing:", basename(csv_file),"\n")
+      system2(
+        command = "gzip",
+        args = shQuote(csv_file)
+      )
+      csv_file <- paste0(csv_file, ".gz")
+    }
+
+    # move file
+    new_file_path <- file.path(financial_year_dir, basename(csv_file))
+    file.copy(csv_file, new_file_path)
+    file.remove(csv_file)
+    cat("Moved:", csv_file, "to", new_file_path, "\n")
+  }
+}


### PR DESCRIPTION
I am sure this R script is absolutely super faster than the original Python script. The reason is Python is running on the local laptop. The specific steps are downloading the files from the server and then uploading the files to the new folder in the server. Instead, R moves files directly on the server. The time consumption is pretty much similar to that of what we do on the local laptop. 

In light of this, when we want to move files between folders on the server, the best way to do is to use Posit. There are two ways to achieve this. 

1. Use the R command `file.move()`, `file.copy`, etc. 
2. Use the Posit user interface to do so. In file table, select "More", and we can move, duplicate, or copy files on the server.

To be short, if we do something via Microsoft Explorer, it is highly likely that we are downloading and uploading files and draining the VPN. If we do something via Posit, it is done directly within the server, which is fast and less resource-consuming.

Feel free to make comments.