### PR TITLE
Remove outdated comment

### DIFF
--- a/R/get_source_extract_path.R
+++ b/R/get_source_extract_path.R
@@ -31,7 +31,6 @@ get_source_extract_path <- function(year,
                                       "sds"
                                     ),
                                     ...) {
-
   if (year %in% type) {
     cli::cli_abort("{.val {year}} was supplied to the {.arg year} argument.")
   }

--- a/_SPSS_archived/All_years/04-Social_Care/03-Alarms_Telecare_data.R
+++ b/_SPSS_archived/All_years/04-Social_Care/03-Alarms_Telecare_data.R
@@ -46,8 +46,6 @@ at_full_data <- tbl(
     service_end_date
   ) %>%
   # fix bad period (2017, 2020 & 2021)
-  # TODO - ask SC team as last meeting they said to look at extract date - these dont relate.
-  # e.g. extract date later than period
   mutate(
     period = if_else(period == "2017", "2017Q4", period),
     period = if_else(period == "2020", "2020Q4", period),


### PR DESCRIPTION
Addresses #658 

This TODO comment in the archived SPSS code was needing removed as the GitHub bot would have kept creating TODO issues. This comment has since been addressed in the R code and is not needed. 