### PR TITLE
Use `create_sending_location_test_flags` in demographic tests

### DIFF
--- a/R/process_tests_sc_demographics.R
+++ b/R/process_tests_sc_demographics.R
@@ -41,6 +41,7 @@ produce_sc_demog_lookup_tests <- function(data) {
       n_missing_sending_loc = is.na(.data$sending_location),
       n_missing_sc_id = is.na(.data$social_care_id)
     ) %>%
+    create_sending_location_test_flags(.data$sending_location) %>%
     # remove variables that won't be summed
     dplyr::select(
       -c(


### PR DESCRIPTION
Linked to #818 

Please see the comment in #818 this could only be applied to the sc demographics tests. Small change to include this in those tests. 