### PR TITLE
Bug - keep population filter and nsu pop not working

### DIFF
--- a/R/add_keep_population_flag.R
+++ b/R/add_keep_population_flag.R
@@ -81,8 +81,8 @@ add_keep_population_flag <- function(individual_file, year) {
         # If they are a non-service-user we want to keep them
         flag_to_remove = dplyr::if_else(nsu == 1, 0, flag_to_remove)
       ) %>%
-    # Remove anyone who was flagged as 1 from above.
-    dplyr::filter(flag_to_remove == 0) %>%
+      # Remove anyone who was flagged as 1 from above.
+      dplyr::filter(flag_to_remove == 0) %>%
       # Calculate the populations of the whole SLF and of the NSU.
       dplyr::group_by(locality, age_group, gender) %>%
       dplyr::mutate(

--- a/R/add_keep_population_flag.R
+++ b/R/add_keep_population_flag.R
@@ -101,10 +101,11 @@ add_keep_population_flag <- function(individual_file, year) {
           scaling_factor > 1 ~ 1,
           .default = scaling_factor
         ),
-        keep_nsu = rbinom(1, 1, scaling_factor)
+        keep_nsu = rbinom(nsu_population, 1, scaling_factor)
       ) %>%
       dplyr::filter(keep_nsu == 1L) %>%
-      dplyr::ungroup()
+      dplyr::ungroup() %>%
+      dplyr::select(-flag_to_remove)
 
     # step 3: match the flag back onto the slf
     individual_file <- individual_file %>%


### PR DESCRIPTION
We had a call to discuss the filter for deaths at the mid point of calendar year. This includes the changes we discussed. There was also the issue of the function `rbinom` not working correctly and selecting out whole groups rather than random samples from each group. This now works. I will run the code tomorrow to produce some of the tables but Rachel and I checked the keep population flag counts for 1819 and it seems a lot more reasonable with the figures. Great work everyone! Thanks 