### PR TITLE
Bug - `vctrs` error when passing `processed_data_list`

### DIFF
--- a/R/create_episode_file.R
+++ b/R/create_episode_file.R
@@ -31,6 +31,8 @@ create_episode_file <- function(
     sc_client = read_file(get_sc_client_lookup_path(year)),
     write_to_disk = TRUE,
     anon_chi_out = TRUE) {
+  processed_data_list <- purrr::discard(processed_data_list, ~ is.null(.x) | identical(.x, tibble::tibble()))
+
   episode_file <- dplyr::bind_rows(processed_data_list) %>%
     create_cost_inc_dna() %>%
     apply_cost_uplift() %>%


### PR DESCRIPTION
I have been having an issue when trying to run the episode file. I get an error with the `vctrs` package as R doesnt like when you try to do a `bind_rows()` on a list of data which has some empty data. The work around is to remove this before processing the episode file 