### PR TITLE
Fix duplicate episode sc send lca

### DIFF
--- a/R/create_episode_file.R
+++ b/R/create_episode_file.R
@@ -438,7 +438,7 @@ join_sc_client <- function(data,
     # Match on client variables by chi
     data_file <- data %>%
       dplyr::left_join(
-        sc_client %>% dplyr::select(-sc_send_lca),
+        sc_client,
         by = "chi",
         relationship = "many-to-one"
       )

--- a/R/create_episode_file.R
+++ b/R/create_episode_file.R
@@ -435,7 +435,8 @@ join_sc_client <- function(data,
   if (file_type == "episode") {
     # Match on client variables by chi
     data_file <- data %>%
-      dplyr::left_join(sc_client,
+      dplyr::left_join(
+        sc_client %>% dplyr::select(-sc_send_lca),
         by = "chi",
         relationship = "many-to-one"
       )

--- a/R/process_lookup_sc_client.R
+++ b/R/process_lookup_sc_client.R
@@ -150,9 +150,6 @@ process_lookup_sc_client <-
       )) == "Not Known")) %>%
       dplyr::arrange(chi, count_not_known) %>%
       dplyr::distinct(chi, .keep_all = TRUE) %>%
-      dplyr::mutate(
-        sc_send_lca = convert_sc_sending_location_to_lca(sending_location)
-      ) %>%
       dplyr::select(-sending_location)
 
     if (write_to_disk) {

--- a/run_slf_process_manually.R
+++ b/run_slf_process_manually.R
@@ -4,16 +4,16 @@ library(createslf)
 
 ---
 
-## UPDATE: Year you would like to run ##
-year <- "2223"
+  ## UPDATE: Year you would like to run ##
+  year <- "2223"
 
 ## UPDATE: Year on "processed_data_list_XXX" ##
 processed_data_list <- targets::tar_read("processed_data_list_2223")
 
 ---
 
-# Run episode file
-create_episode_file(processed_data_list, year = year) %>%
+  # Run episode file
+  create_episode_file(processed_data_list, year = year) %>%
   process_tests_episode_file(year = year)
 
 # Run individual file


### PR DESCRIPTION
See the create_episode_file, 


line 34, `episode_file <- dplyr::bind_rows(processed_data_list) %>%`, the `bind_rows` matched all episode records by chi, sending_location, sc_send_lca, etc. 
line 37, `store_ep_file_vars(` drops not very necessary columns/variables, including `sc_send_lca`, and will join back at line 137.
line 136, `join_sc_client(year, sc_client = sc_client, file_type = "episode") %>%` add sc_send_lca column again, which cause two sc_send_lca columns.

Since line 136 only matches by sending_location, it seems not as reliable as line 34. I prefer to drop `sc_send_lca` column added by line 136. Feel free to comment.