### PR TITLE
Bug - NSUs being assigned psychiatry in the service use cohort

### DIFF
--- a/R/create_demographic_lookup.R
+++ b/R/create_demographic_lookup.R
@@ -344,18 +344,21 @@ assign_d_cohort_high_cc <- function(dementia,
                                     liver,
                                     cancer,
                                     spec) {
-  high_cc <-
+  high_cc <- dplyr::case_when(
+    spec == "G5" ~ TRUE,
     # FOR FUTURE: PhysicalandSensoryDisabilityClientGroup or LearningDisabilityClientGroup = "Y",
     # then high_cc_cohort = TRUE
     # FOR FUTURE: Care home removed, here's the code: .data$recid = "CH" & age < 65
-    rowSums(dplyr::pick(c(
+    (rowSums(dplyr::pick(c(
       "dementia",
       "hefailure",
       "refailure",
       "liver",
       "cancer"
-    )), na.rm = TRUE) >= 1L |
-      spec == "G5"
+    )), na.rm = TRUE) >= 1L) ~ TRUE,
+    .default = FALSE
+  )
+
   return(high_cc)
 }
 

--- a/R/create_service_use_lookup.R
+++ b/R/create_service_use_lookup.R
@@ -908,7 +908,13 @@ assign_cohort_names <- function(data) {
         # Situation where no cost is greater than another,
         # so the maximum is the same  as the mean
         .data$cost_max == rowSums(
-          dplyr::pick("psychiatry_cost":"residential_care_cost")
+          dplyr::pick(c(
+            "psychiatry_cost", "maternity_cost", "geriatric_cost",
+            "elective_inpatient_cost", "limited_daycases_cost",
+            "routine_daycase_cost", "single_emergency_cost",
+            "multiple_emergency_cost", "prescribing_cost",
+            "outpatient_cost", "ae2_cost", "residential_care_cost"
+          ))
         ) / 12.0 ~ "Unassigned",
         .data$cost_max == .data$psychiatry_cost ~ "Psychiatry",
         .data$cost_max == .data$maternity_cost ~ "Maternity",


### PR DESCRIPTION
Due to a coding error, the `dplyr::pick` was not working correctly when trying to take the average for assigning the label `unassigned`. This was causing NSUs to have the label `psychiatry` attached as this was the next name available. The fix is to specify all of the columns needed to take an average for assigning the label `unassigned`. This has a big impact on the figures. 

The  current 'live' files:

```
  service_use_cohort       n
   <chr>                <int>
 1 Elective Inpatient  488510
 2 Geriatric           293863
 3 Limited Daycases    725538
 4 Maternity           206488
 5 Multiple Emergency 1140659
 6 Outpatients        1102837
 7 Prescribing        3982957
 **8 Psychiatry         1601193**
 9 Routine Daycase     178739
10 Single Emergency   1116014
**11 Unassigned          250917**
12 Unscheduled Care   1718283
13 NA                   55697

```

after the fix: 

```
   service_use_cohort       n
   <chr>                <int>
 1 Elective Inpatient  488521
 2 Geriatric           293869
 3 Limited Daycases    725583
 4 Maternity           206488
 5 Multiple Emergency 1140688
 6 Outpatients        1102878
 7 Prescribing        3982958
 **8 Psychiatry          111859**
 9 Routine Daycase     178742
10 Single Emergency   1116042
**11 Unassigned         1740237**
12 Unscheduled Care   1718269
13 NA                   55180
```

Ive asked the source team if they can run through a test to see the impact on their figures so i am opening this as a draft for now incase further changes are needed. 

closes #907