### PR TITLE
Bug - `high_cc` in demographic cohort showing `NAs` instead of `TRUE/FALSE`

### DIFF
--- a/R/create_demographic_lookup.R
+++ b/R/create_demographic_lookup.R
@@ -344,18 +344,21 @@ assign_d_cohort_high_cc <- function(dementia,
                                     liver,
                                     cancer,
                                     spec) {
-  high_cc <-
+  high_cc <- dplyr::case_when(
+    spec == "G5" ~ TRUE,
     # FOR FUTURE: PhysicalandSensoryDisabilityClientGroup or LearningDisabilityClientGroup = "Y",
     # then high_cc_cohort = TRUE
     # FOR FUTURE: Care home removed, here's the code: .data$recid = "CH" & age < 65
-    rowSums(dplyr::pick(c(
+    (rowSums(dplyr::pick(c(
       "dementia",
       "hefailure",
       "refailure",
       "liver",
       "cancer"
-    )), na.rm = TRUE) >= 1L |
-      spec == "G5"
+    )), na.rm = TRUE) >= 1L) ~ TRUE,
+    .default = FALSE
+  )
+
   return(high_cc)
 }
 


### PR DESCRIPTION
Issue was caused by the conditional statement not recognising `spec == G5`. The fix is to wrap the code in a `case_when` statement to make sure everything is being captured. 

This is also updated in the code for #908 so that we can test the demographic cohorts

closes #910 