### PR TITLE
Bug - Fix get pop path failing and preventing the indiv file from running. 

### DIFF
--- a/R/add_keep_population_flag.R
+++ b/R/add_keep_population_flag.R
@@ -15,7 +15,7 @@ add_keep_population_flag <- function(individual_file, year) {
   } else {
     ## Obtain the population estimates for Locality AgeGroup and Gender.
     pop_estimates <-
-      readr::read_rds(get_datazone_pop_path("DataZone2011_pop_est_2011_2021.rds")) %>%
+      readr::read_rds(get_pop_path(type = "datazone")) %>%
       dplyr::select(year, datazone2011, sex, age0:age90plus)
 
     # Step 1: Obtain the population estimates for Locality, AgeGroup, and Gender

--- a/R/get_lookup_paths.R
+++ b/R/get_lookup_paths.R
@@ -126,7 +126,7 @@ get_pop_path <- function(file_name = NULL,
     "intzone" ~ stringr::str_glue("IntZone_pop_est_2011_\\d+?\\.{ext}")
   )
 
-  datazone_pop_path <- get_file_path(
+  pop_path <- get_file_path(
     directory = pop_dir,
     file_name = file_name,
     ext = ext,

--- a/Rmarkdown/costs_district_nursing.Rmd
+++ b/Rmarkdown/costs_district_nursing.Rmd
@@ -75,7 +75,7 @@ dn_raw_costs_contacts <- left_join(dn_raw_contacts,
 # Of the two HSCPs, Argyll and Bute provides the
 # District Nursing data which is 27% of the population.
 
-population_lookup <- read_file(get_datazone_pop_path("HSCP2019_pop_est_1981_2021.rds")) %>%
+population_lookup <- read_file(get_pop_path(type = "datazone")) %>%
   # Select only the HSCPs for NHS Highland & years since 2015
   filter(
     hscp2019 %in% c("S37000004", "S37000016"),

--- a/tests/testthat/test-get_lookup_paths.R
+++ b/tests/testthat/test-get_lookup_paths.R
@@ -48,13 +48,11 @@ test_that("SIMD file path returns as expected", {
 
 test_that("population estimates file path returns as expected", {
   suppressMessages({
-    expect_s3_class(get_datazone_pop_path(), "fs_path")
+    expect_s3_class(get_pop_path(type = "datazone"), "fs_path")
 
-    expect_equal(fs::path_ext(get_datazone_pop_path()), "rds")
+    expect_equal(fs::path_ext(get_pop_path(type = "datazone")), "rds")
 
-    expect_match(get_datazone_pop_path(), "DataZone2011_pop_est_2001_\\d+?")
-
-    expect_true(fs::file_exists(get_datazone_pop_path()))
+    expect_true(fs::file_exists(get_pop_path(type = "datazone")))
   })
 })
 


### PR DESCRIPTION
Found an issue which was preventing the individual file from running. I think this was missed on the PR #859 where the function works well but we forgot to apply this within the code. Tested the changes while looking at missing variables and it works fine now.