### PR TITLE
Bug - deal with missing variables

### DIFF
--- a/R/add_hri_variables.R
+++ b/R/add_hri_variables.R
@@ -82,7 +82,7 @@ add_hri_variables <- function(
       "mh_episodes",
       "gls_episodes",
       "op_newcons_attendances",
-      # op_newcons_dnas,
+      "op_newcons_dnas",
       "ae_attendances",
       "pis_paid_items",
       "ooh_cases"

--- a/R/aggregate_by_chi.R
+++ b/R/aggregate_by_chi.R
@@ -89,6 +89,7 @@ aggregate_by_chi <- function(episode_file, exclude_sc_var = FALSE) {
         "episodes",
         "beddays",
         "cost",
+        "_dnas",
         "attendances",
         "attend",
         "contacts",
@@ -109,8 +110,7 @@ aggregate_by_chi <- function(episode_file, exclude_sc_var = FALSE) {
     vars_start_with(
       episode_file,
       "sds_option"
-    ),
-    "health_net_cost_inc_dnas"
+    )
   )
   cols4 <- cols4[!(cols4 %in% "ch_cis_episodes")]
   if (exclude_sc_var) {

--- a/R/create_episode_file.R
+++ b/R/create_episode_file.R
@@ -143,8 +143,9 @@ create_episode_file <- function(
     episode_file <- episode_file %>%
       dplyr::mutate(
         ch_chi_cis = NA,
-        sc_id_cis = NA,
+        ch_sc_id_cis = NA,
         ch_name = NA,
+        ch_postcode = NA,
         ch_adm_reason = NA,
         ch_provider = NA,
         ch_nursing = NA,
@@ -159,7 +160,9 @@ create_episode_file <- function(
         hc_cost_q4 = NA,
         hc_provider = NA,
         hc_reablement = NA,
-        sds_option_4 = NA,
+        person_id = NA,
+        sc_latest_submission = NA,
+        sc_send_lca = NA,
         sc_living_alone = NA,
         sc_support_from_unpaid_carer = NA,
         sc_social_worker = NA,


### PR DESCRIPTION
While looking into the old files I noticed there were some missing variables which include: 
Individual file: 
- `op_newcons_dnas`
- `op_cost_dnas`

Latest year file: 
- `ch_sc_id_cis`
- `ch_postcode`
- `person_id`
- `sc_latest_submission`
- `sc_send_lca`

This PR corrects the code for dealing with these variables 