### PR TITLE
Move `cli` warning messages before `return()`

### DIFF
--- a/R/add_activity_after_death_flag.R
+++ b/R/add_activity_after_death_flag.R
@@ -13,8 +13,6 @@ add_activity_after_death_flag <- function(
     year,
     deaths_data = read_file(get_combined_slf_deaths_lookup_path()) %>%
       slfhelper::get_chi()) {
-  cli::cli_alert_info("Add activity after death flag function started at {Sys.time()}")
-
   # to skip warnings no visible binding for global variable ‘.’
   . <- NULL
 
@@ -94,7 +92,7 @@ add_activity_after_death_flag <- function(
     dplyr::select(-death_date_boxi) %>%
     dplyr::distinct()
 
-
+  cli::cli_alert_info("Add activity after death flag function started at {Sys.time()}")
 
   return(final_data)
 }

--- a/R/add_activity_after_death_flag.R
+++ b/R/add_activity_after_death_flag.R
@@ -92,7 +92,7 @@ add_activity_after_death_flag <- function(
     dplyr::select(-death_date_boxi) %>%
     dplyr::distinct()
 
-  cli::cli_alert_info("Add activity after death flag function started at {Sys.time()}")
+  cli::cli_alert_info("Add activity after death flag function finished at {Sys.time()}")
 
   return(final_data)
 }

--- a/R/add_hri_variables.R
+++ b/R/add_hri_variables.R
@@ -46,7 +46,7 @@ flag_non_scottish_residents <- function(
     ) %>%
     dplyr::select(-"dummy_postcode", -"eng_prac")
 
-  cli::cli_alert_info("Add HRI variables function started at {Sys.time()}")
+  cli::cli_alert_info("Add HRI variables function finished at {Sys.time()}")
 
   return(return_data)
 }

--- a/R/add_hri_variables.R
+++ b/R/add_hri_variables.R
@@ -46,6 +46,8 @@ flag_non_scottish_residents <- function(
     ) %>%
     dplyr::select(-"dummy_postcode", -"eng_prac")
 
+  cli::cli_alert_info("Add HRI variables function started at {Sys.time()}")
+
   return(return_data)
 }
 

--- a/R/add_keep_population_flag.R
+++ b/R/add_keep_population_flag.R
@@ -138,6 +138,10 @@ add_keep_population_flag <- function(individual_file, year) {
         )
       )
   }
+
+  cli::cli_alert_info("Add keep population function started at {Sys.time()}")
+
+  return(individual_file)
 }
 
 

--- a/R/add_keep_population_flag.R
+++ b/R/add_keep_population_flag.R
@@ -139,7 +139,7 @@ add_keep_population_flag <- function(individual_file, year) {
       )
   }
 
-  cli::cli_alert_info("Add keep population function started at {Sys.time()}")
+  cli::cli_alert_info("Add keep population function finished at {Sys.time()}")
 
   return(individual_file)
 }

--- a/R/add_nsu_cohort.R
+++ b/R/add_nsu_cohort.R
@@ -116,7 +116,7 @@ add_nsu_cohort <- function(
     ) %>%
     dplyr::select(-dplyr::contains("_nsu"), -"has_chi")
 
-  cli::cli_alert_info("Add NSU cohort function started at {Sys.time()}")
+  cli::cli_alert_info("Add NSU cohort function finished at {Sys.time()}")
 
   return(return_df)
 }

--- a/R/add_nsu_cohort.R
+++ b/R/add_nsu_cohort.R
@@ -13,8 +13,6 @@ add_nsu_cohort <- function(
     data,
     year,
     nsu_cohort = read_file(get_nsu_path(year)) %>% slfhelper::get_chi()) {
-  cli::cli_alert_info("Add NSU cohort function started at {Sys.time()}")
-
   year_param <- year
 
   if (!check_year_valid(year, "nsu")) {
@@ -117,6 +115,8 @@ add_nsu_cohort <- function(
       )
     ) %>%
     dplyr::select(-dplyr::contains("_nsu"), -"has_chi")
+
+  cli::cli_alert_info("Add NSU cohort function started at {Sys.time()}")
 
   return(return_df)
 }

--- a/R/add_ppa_flag.R
+++ b/R/add_ppa_flag.R
@@ -225,7 +225,7 @@ add_ppa_flag <- function(data) {
       .data$cij_ppa
     ))
 
-  cli::cli_alert_info("Add PPA flag function started at {Sys.time()}")
+  cli::cli_alert_info("Add PPA flag function finished at {Sys.time()}")
 
   return(ppa_cij_data)
 }

--- a/R/add_ppa_flag.R
+++ b/R/add_ppa_flag.R
@@ -8,8 +8,6 @@
 #' @return A data frame to use as a lookup of PPAs
 #' @family episode_file
 add_ppa_flag <- function(data) {
-  cli::cli_alert_info("Add PPA flag function started at {Sys.time()}")
-
   check_variables_exist(
     data,
     variables = c(
@@ -226,6 +224,8 @@ add_ppa_flag <- function(data) {
       FALSE,
       .data$cij_ppa
     ))
+
+  cli::cli_alert_info("Add PPA flag function started at {Sys.time()}")
 
   return(ppa_cij_data)
 }

--- a/R/aggregate_by_chi.R
+++ b/R/aggregate_by_chi.R
@@ -197,7 +197,7 @@ aggregate_by_chi <- function(episode_file, year, exclude_sc_var = FALSE) {
   )
   individual_file <- individual_file[, year := year]
 
-  cli::cli_alert_info("Aggregate by CHI function started at {Sys.time()}")
+  cli::cli_alert_info("Aggregate by CHI function finished at {Sys.time()}")
 
   # convert back to tibble
   return(dplyr::as_tibble(individual_file))
@@ -272,7 +272,7 @@ aggregate_ch_episodes <- function(episode_file) {
   # Convert back to tibble if needed
   episode_file <- tibble::as_tibble(episode_file)
 
-  cli::cli_alert_info("Aggregate ch episodes function started at {Sys.time()}")
+  cli::cli_alert_info("Aggregate ch episodes function finished at {Sys.time()}")
 
   return(episode_file)
 }

--- a/R/aggregate_by_chi.R
+++ b/R/aggregate_by_chi.R
@@ -10,8 +10,6 @@
 #'
 #' @inheritParams create_individual_file
 aggregate_by_chi <- function(episode_file, year, exclude_sc_var = FALSE) {
-  cli::cli_alert_info("Aggregate by CHI function started at {Sys.time()}")
-
   # recommended by `data.table` team to tackle the issue
   # "no visible binding for global variable"
   gender <-
@@ -199,6 +197,8 @@ aggregate_by_chi <- function(episode_file, year, exclude_sc_var = FALSE) {
   )
   individual_file <- individual_file[, year := year]
 
+  cli::cli_alert_info("Aggregate by CHI function started at {Sys.time()}")
+
   # convert back to tibble
   return(dplyr::as_tibble(individual_file))
 }
@@ -246,8 +246,6 @@ vars_contain <- function(data, vars, ignore_case = FALSE) {
 #'
 #' @inheritParams create_individual_file
 aggregate_ch_episodes <- function(episode_file) {
-  cli::cli_alert_info("Aggregate ch episodes function started at {Sys.time()}")
-
   # recommended by `data.table` team to tackle the issue
   # "no visible binding for global variable"
   ch_no_cost <-
@@ -273,6 +271,8 @@ aggregate_ch_episodes <- function(episode_file) {
 
   # Convert back to tibble if needed
   episode_file <- tibble::as_tibble(episode_file)
+
+  cli::cli_alert_info("Aggregate ch episodes function started at {Sys.time()}")
 
   return(episode_file)
 }

--- a/R/correct_demographics.R
+++ b/R/correct_demographics.R
@@ -100,7 +100,7 @@ correct_demographics <- function(data, year) {
     data_chi
   )
 
-  cli::cli_alert_info("Correct demographics function started at {Sys.time()}")
+  cli::cli_alert_info("Correct demographics function finished at {Sys.time()}")
 
   return(data)
 }

--- a/R/correct_demographics.R
+++ b/R/correct_demographics.R
@@ -7,8 +7,6 @@
 #'
 #' @return episode files with updated date of birth and ages
 correct_demographics <- function(data, year) {
-  cli::cli_alert_info("Correct demographics function started at {Sys.time()}")
-
   # keep episodes with missing chi
   data_no_chi <- data %>%
     dplyr::filter(is_missing(.data$chi))
@@ -101,6 +99,8 @@ correct_demographics <- function(data, year) {
     data_no_chi,
     data_chi
   )
+
+  cli::cli_alert_info("Correct demographics function started at {Sys.time()}")
 
   return(data)
 }

--- a/R/cost_uplift.R
+++ b/R/cost_uplift.R
@@ -27,7 +27,7 @@ apply_cost_uplift <- function(data) {
     # remove the last uplift column
     dplyr::select(-"uplift")
 
-  cli::cli_alert_info("Apply cost uplift function started at {Sys.time()}")
+  cli::cli_alert_info("Apply cost uplift function finished at {Sys.time()}")
 
   return(data)
 }

--- a/R/cost_uplift.R
+++ b/R/cost_uplift.R
@@ -5,8 +5,6 @@
 #' @return episode data with uplifted costs
 #' @family episode_file
 apply_cost_uplift <- function(data) {
-  cli::cli_alert_info("Apply cost uplift function started at {Sys.time()}")
-
   data <- data %>%
     # attach a uplift scale as the last column
     lookup_uplift() %>%
@@ -28,6 +26,8 @@ apply_cost_uplift <- function(data) {
     ) %>%
     # remove the last uplift column
     dplyr::select(-"uplift")
+
+  cli::cli_alert_info("Apply cost uplift function started at {Sys.time()}")
 
   return(data)
 }

--- a/R/create_episode_file.R
+++ b/R/create_episode_file.R
@@ -33,6 +33,8 @@ create_episode_file <- function(
     sc_client = read_file(get_sc_client_lookup_path(year)) %>% slfhelper::get_chi(),
     write_to_disk = TRUE,
     anon_chi_out = TRUE) {
+  cli::cli_alert_info("Create episode file function started at {Sys.time()}")
+
   processed_data_list <- purrr::discard(processed_data_list, ~ is.null(.x) | identical(.x, tibble::tibble()))
 
   episode_file <- dplyr::bind_rows(processed_data_list) %>%
@@ -265,8 +267,6 @@ create_episode_file <- function(
 #'
 #' @return `data` with only the `vars_to_keep` kept
 store_ep_file_vars <- function(data, year, vars_to_keep) {
-  cli::cli_alert_info("Store episode file variables function started at {Sys.time()}")
-
   tempfile_path <- get_file_path(
     directory = get_year_dir(year),
     file_name = stringr::str_glue("temp_ep_file_variable_store_{year}.parquet"),
@@ -289,6 +289,8 @@ store_ep_file_vars <- function(data, year, vars_to_keep) {
       path = tempfile_path
     )
 
+  cli::cli_alert_info("Store episode file variables function started at {Sys.time()}")
+
   return(
     dplyr::select(
       data,
@@ -304,8 +306,6 @@ store_ep_file_vars <- function(data, year, vars_to_keep) {
 #'
 #' @return The full SLF data.
 load_ep_file_vars <- function(data, year) {
-  cli::cli_alert_info("Load episode file variable function started at {Sys.time()}")
-
   tempfile_path <- get_file_path(
     directory = get_year_dir(year),
     file_name = stringr::str_glue("temp_ep_file_variable_store_{year}.parquet"),
@@ -324,6 +324,8 @@ load_ep_file_vars <- function(data, year) {
 
   fs::file_delete(tempfile_path)
 
+  cli::cli_alert_info("Load episode file variable function started at {Sys.time()}")
+
   return(full_data)
 }
 
@@ -333,8 +335,6 @@ load_ep_file_vars <- function(data, year) {
 #'
 #' @return A data frame with CIJ markers filled in for those missing.
 fill_missing_cij_markers <- function(data) {
-  cli::cli_alert_info("Fill missing cij markers function started at {Sys.time()}")
-
   fixable_data <- data %>%
     dplyr::filter(
       .data[["recid"]] %in% c("01B", "04B", "GLS", "02B", "DD") & !is.na(.data[["chi"]])
@@ -380,6 +380,8 @@ fill_missing_cij_markers <- function(data) {
 
   return_data <- dplyr::bind_rows(non_fixable_data, fixed_data)
 
+  cli::cli_alert_info("Fill missing cij markers function started at {Sys.time()}")
+
   return(return_data)
 }
 
@@ -389,14 +391,12 @@ fill_missing_cij_markers <- function(data) {
 #'
 #' @return The data with CIJ variables corrected.
 correct_cij_vars <- function(data) {
-  cli::cli_alert_info("Correct cij variables function started at {Sys.time()}")
-
   check_variables_exist(
     data,
     c("chi", "recid", "cij_admtype", "cij_pattype_code")
   )
 
-  data %>%
+  data <- data %>%
     # Change some values of cij_pattype_code based on cij_admtype
     dplyr::mutate(
       cij_admtype = dplyr::if_else(
@@ -424,6 +424,10 @@ correct_cij_vars <- function(data) {
         9L ~ "Other"
       )
     )
+
+  cli::cli_alert_info("Correct cij variables function started at {Sys.time()}")
+
+  return(data)
 }
 
 #' Create cost total net inc DNA
@@ -432,13 +436,11 @@ correct_cij_vars <- function(data) {
 #'
 #' @return The data with cost including dna.
 create_cost_inc_dna <- function(data) {
-  cli::cli_alert_info("Create cost inc dna function started at {Sys.time()}")
-
   check_variables_exist(data, c("cost_total_net", "attendance_status"))
 
   # Create cost including DNAs and modify costs
   # not including DNAs using cattend
-  data %>%
+  data <- data %>%
     dplyr::mutate(
       cost_total_net_inc_dnas = .data$cost_total_net,
       # In the Cost_Total_Net column set the cost for
@@ -449,6 +451,10 @@ create_cost_inc_dna <- function(data) {
         .data$cost_total_net
       )
     )
+
+  cli::cli_alert_info("Create cost inc dna function started at {Sys.time()}")
+
+  return(data)
 }
 
 #' Create the cohort lookups
@@ -458,8 +464,6 @@ create_cost_inc_dna <- function(data) {
 #'
 #' @return The data unchanged (the cohorts are written to disk)
 create_cohort_lookups <- function(data, year, update = latest_update()) {
-  cli::cli_alert_info("Create cohort lookups function started at {Sys.time()}")
-
   create_demographic_cohorts(
     data,
     year,
@@ -474,6 +478,7 @@ create_cohort_lookups <- function(data, year, update = latest_update()) {
     write_to_disk = TRUE
   )
 
+  cli::cli_alert_info("Create cohort lookups function started at {Sys.time()}")
 
   return(data)
 }
@@ -499,8 +504,6 @@ join_cohort_lookups <- function(
       col_select = c("anon_chi", "service_use_cohort")
     ) %>%
       slfhelper::get_chi()) {
-  cli::cli_alert_info("Join cohort lookups function started at {Sys.time()}")
-
   join_cohort_lookups <- data %>%
     dplyr::left_join(
       demographic_cohort,
@@ -510,6 +513,8 @@ join_cohort_lookups <- function(
       service_use_cohort,
       by = "chi"
     )
+
+  cli::cli_alert_info("Join cohort lookups function started at {Sys.time()}")
 
   return(join_cohort_lookups)
 }
@@ -527,8 +532,6 @@ join_sc_client <- function(data,
                            year,
                            sc_client = read_file(get_sc_client_lookup_path(year)) %>% slfhelper::get_chi(),
                            file_type = c("episode", "individual")) {
-  cli::cli_alert_info("Join social care client function started at {Sys.time()}")
-
   if (!check_year_valid(year, type = "client")) {
     data_file <- data
     return(data_file)
@@ -550,6 +553,8 @@ join_sc_client <- function(data,
         relationship = "one-to-one"
       )
   }
+
+  cli::cli_alert_info("Join social care client function started at {Sys.time()}")
 
   return(data_file)
 }

--- a/R/create_episode_file.R
+++ b/R/create_episode_file.R
@@ -289,7 +289,7 @@ store_ep_file_vars <- function(data, year, vars_to_keep) {
       path = tempfile_path
     )
 
-  cli::cli_alert_info("Store episode file variables function started at {Sys.time()}")
+  cli::cli_alert_info("Store episode file variables function finished at {Sys.time()}")
 
   return(
     dplyr::select(
@@ -324,7 +324,7 @@ load_ep_file_vars <- function(data, year) {
 
   fs::file_delete(tempfile_path)
 
-  cli::cli_alert_info("Load episode file variable function started at {Sys.time()}")
+  cli::cli_alert_info("Load episode file variable function finished at {Sys.time()}")
 
   return(full_data)
 }
@@ -380,7 +380,7 @@ fill_missing_cij_markers <- function(data) {
 
   return_data <- dplyr::bind_rows(non_fixable_data, fixed_data)
 
-  cli::cli_alert_info("Fill missing cij markers function started at {Sys.time()}")
+  cli::cli_alert_info("Fill missing cij markers function finished at {Sys.time()}")
 
   return(return_data)
 }
@@ -425,7 +425,7 @@ correct_cij_vars <- function(data) {
       )
     )
 
-  cli::cli_alert_info("Correct cij variables function started at {Sys.time()}")
+  cli::cli_alert_info("Correct cij variables function finished at {Sys.time()}")
 
   return(data)
 }
@@ -452,7 +452,7 @@ create_cost_inc_dna <- function(data) {
       )
     )
 
-  cli::cli_alert_info("Create cost inc dna function started at {Sys.time()}")
+  cli::cli_alert_info("Create cost inc dna function finished at {Sys.time()}")
 
   return(data)
 }
@@ -478,7 +478,7 @@ create_cohort_lookups <- function(data, year, update = latest_update()) {
     write_to_disk = TRUE
   )
 
-  cli::cli_alert_info("Create cohort lookups function started at {Sys.time()}")
+  cli::cli_alert_info("Create cohort lookups function finished at {Sys.time()}")
 
   return(data)
 }
@@ -514,7 +514,7 @@ join_cohort_lookups <- function(
       by = "chi"
     )
 
-  cli::cli_alert_info("Join cohort lookups function started at {Sys.time()}")
+  cli::cli_alert_info("Join cohort lookups function finished at {Sys.time()}")
 
   return(join_cohort_lookups)
 }
@@ -554,7 +554,7 @@ join_sc_client <- function(data,
       )
   }
 
-  cli::cli_alert_info("Join social care client function started at {Sys.time()}")
+  cli::cli_alert_info("Join social care client function finished at {Sys.time()}")
 
   return(data_file)
 }

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -294,7 +294,6 @@ add_all_columns <- function(episode_file, year) {
 #' @param condition Condition to create new columns based on
 #' @family individual_file
 add_acute_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
@@ -310,7 +309,6 @@ add_acute_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_mat_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
@@ -326,7 +324,6 @@ add_mat_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_mh_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
@@ -335,14 +332,13 @@ add_mh_columns <- function(episode_file, prefix, condition) {
   cli::cli_alert_info("Add mental health columns function finished at {Sys.time()}")
 
   return(episode_file)
-  }
+}
 
 #' Add GLS columns
 #'
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_gls_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
@@ -358,7 +354,6 @@ add_gls_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_op_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition)
@@ -385,7 +380,6 @@ add_op_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_ae_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, cost = TRUE) %>%
@@ -394,7 +388,6 @@ add_ae_columns <- function(episode_file, prefix, condition) {
   cli::cli_alert_info("Add A&E columns function finished at {Sys.time()}")
 
   return(episode_file)
-
 }
 
 #' Add PIS columns
@@ -402,7 +395,6 @@ add_ae_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_pis_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, cost = TRUE) %>%
@@ -410,14 +402,13 @@ add_pis_columns <- function(episode_file, prefix, condition) {
   cli::cli_alert_info("Add prescribing columns function finished at {Sys.time()}")
 
   return(episode_file)
-  }
+}
 
 #' Add OoH columns
 #'
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_ooh_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, cost = TRUE) %>%
@@ -455,7 +446,6 @@ add_ooh_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_dn_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   if ("total_no_dn_contacts" %in% names(episode_file)) {
     episode_file <- episode_file %>%
@@ -473,7 +463,7 @@ add_dn_columns <- function(episode_file, prefix, condition) {
       dplyr::mutate("{prefix}_contacts" := NA_integer_)
   }
 
-   cli::cli_alert_info("Add district nursing columns function finished at {Sys.time()}")
+  cli::cli_alert_info("Add district nursing columns function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -483,13 +473,12 @@ add_dn_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_cmh_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
     dplyr::mutate("{prefix}_contacts" := dplyr::if_else(eval(condition), 1L, NA_integer_))
 
-   cli::cli_alert_info("Add communicty mental health columns function finished at {Sys.time()}")
+  cli::cli_alert_info("Add communicty mental health columns function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -499,7 +488,6 @@ add_cmh_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_dd_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   condition_delay <- substitute(condition & primary_delay_reason != "9")
   episode_file <- episode_file %>%
@@ -524,13 +512,12 @@ add_dd_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_nsu_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
     dplyr::mutate("{prefix}" := dplyr::if_else(eval(condition), 1L, NA_integer_))
 
-   cli::cli_alert_info("Add non service users columns function finished at {Sys.time()}")
+  cli::cli_alert_info("Add non service users columns function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -540,13 +527,12 @@ add_nsu_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_nrs_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
     dplyr::mutate("{prefix}" := dplyr::if_else(eval(condition), 1L, NA_integer_))
 
-   cli::cli_alert_info("Add nrs columns function finished at {Sys.time()}")
+  cli::cli_alert_info("Add nrs columns function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -556,12 +542,11 @@ add_nrs_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_hl1_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition)
 
-    cli::cli_alert_info("Add homelessness columns function finished at {Sys.time()}")
+  cli::cli_alert_info("Add homelessness columns function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -571,7 +556,6 @@ add_hl1_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_ch_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
@@ -606,7 +590,6 @@ add_ch_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_hc_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
 
   episode_file <- episode_file %>%
@@ -655,7 +638,6 @@ add_hc_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_at_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
@@ -674,7 +656,6 @@ add_at_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_sds_columns <- function(episode_file, prefix, condition) {
-
   condition <- substitute(condition)
   episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
@@ -701,7 +682,6 @@ add_sds_columns <- function(episode_file, prefix, condition) {
 #' cij_pattype (lgl)
 #' @family individual_file
 add_ipdc_cols <- function(episode_file, prefix, condition, ipdc_d = TRUE, elective = TRUE) {
-
   condition_i <- substitute(eval(condition) & ipdc == "I")
   episode_file <- episode_file %>%
     dplyr::mutate(
@@ -749,8 +729,6 @@ add_ipdc_cols <- function(episode_file, prefix, condition, ipdc_d = TRUE, electi
 #' @param cost Whether to create prefix_cost col, e.g. "Acute_cost"
 #' @family individual_file
 add_standard_cols <- function(episode_file, prefix, condition, episode = FALSE, cost = FALSE) {
-
-
   if (episode) {
     episode_file <- dplyr::mutate(episode_file, "{prefix}_episodes" := dplyr::if_else(eval(condition), 1L, NA_integer_))
   }

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -294,12 +294,15 @@ add_all_columns <- function(episode_file, year) {
 #' @param condition Condition to create new columns based on
 #' @family individual_file
 add_acute_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add acute columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
     add_ipdc_cols(prefix, condition)
+
+  cli::cli_alert_info("Add acute columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add Mat columns
@@ -307,12 +310,15 @@ add_acute_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_mat_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add maternity columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
     add_ipdc_cols(prefix, condition, elective = FALSE)
+
+  cli::cli_alert_info("Add maternity columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add MH columns
@@ -320,25 +326,31 @@ add_mat_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_mh_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add mental health columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
     add_ipdc_cols(prefix, condition, ipdc_d = FALSE)
-}
+
+  cli::cli_alert_info("Add mental health columns function finished at {Sys.time()}")
+
+  return(episode_file)
+  }
 
 #' Add GLS columns
 #'
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_gls_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add geriatric long stay columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
     add_ipdc_cols(prefix, condition, ipdc_d = FALSE)
+
+  cli::cli_alert_info("Add geriatric long stay columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add OP columns
@@ -346,7 +358,6 @@ add_gls_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_op_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add outpatient columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file <- episode_file %>%
@@ -363,6 +374,9 @@ add_op_columns <- function(episode_file, prefix, condition) {
       "{prefix}_newcons_dnas" := dplyr::if_else(eval(condition_5_8), 1L, NA_integer_),
       "{prefix}_cost_dnas" := dplyr::if_else(eval(condition_5_8), .data$cost_total_net_inc_dnas, NA_real_)
     )
+
+  cli::cli_alert_info("Add outpatient columns function finished at {Sys.time()}")
+
   return(episode_file)
 }
 
@@ -371,12 +385,16 @@ add_op_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_ae_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add A&E columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, cost = TRUE) %>%
     dplyr::mutate("{prefix}_attendances" := dplyr::if_else(eval(condition), 1L, NA_integer_))
+
+  cli::cli_alert_info("Add A&E columns function finished at {Sys.time()}")
+
+  return(episode_file)
+
 }
 
 #' Add PIS columns
@@ -384,20 +402,21 @@ add_ae_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_pis_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add prescribing columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition, cost = TRUE) %>%
     dplyr::mutate("{prefix}_paid_items" := dplyr::if_else(eval(condition), .data$no_paid_items, NA_integer_))
-}
+  cli::cli_alert_info("Add prescribing columns function finished at {Sys.time()}")
+
+  return(episode_file)
+  }
 
 #' Add OoH columns
 #'
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_ooh_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add out of hours columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file <- episode_file %>%
@@ -426,6 +445,8 @@ add_ooh_columns <- function(episode_file, prefix, condition) {
       )
     )
 
+  cli::cli_alert_info("Add out of hours columns function finished at {Sys.time()}")
+
   return(episode_file)
 }
 
@@ -434,11 +455,10 @@ add_ooh_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_dn_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add district nursing columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   if ("total_no_dn_contacts" %in% names(episode_file)) {
-    episode_file %>%
+    episode_file <- episode_file %>%
       add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
       dplyr::mutate(
         "{prefix}_contacts" := dplyr::if_else(
@@ -448,10 +468,14 @@ add_dn_columns <- function(episode_file, prefix, condition) {
         )
       )
   } else {
-    episode_file %>%
+    episode_file <- episode_file %>%
       add_standard_cols(prefix, condition, episode = TRUE, cost = TRUE) %>%
       dplyr::mutate("{prefix}_contacts" := NA_integer_)
   }
+
+   cli::cli_alert_info("Add district nursing columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add CMH columns
@@ -459,12 +483,15 @@ add_dn_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_cmh_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add communicty mental health columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
     dplyr::mutate("{prefix}_contacts" := dplyr::if_else(eval(condition), 1L, NA_integer_))
+
+   cli::cli_alert_info("Add communicty mental health columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add DD columns
@@ -472,7 +499,6 @@ add_cmh_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_dd_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add delayed discharges columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   condition_delay <- substitute(condition & primary_delay_reason != "9")
@@ -487,6 +513,9 @@ add_dd_columns <- function(episode_file, prefix, condition) {
       "{prefix}_Code9_episodes" := dplyr::if_else(eval(condition_delay_9), 1L, NA_integer_),
       "{prefix}_Code9_beddays" := dplyr::if_else(eval(condition_delay_9), .data$yearstay, NA_real_)
     )
+
+  cli::cli_alert_info("Add delayed discharges columns function finished at {Sys.time()}")
+
   return(episode_file)
 }
 
@@ -495,12 +524,15 @@ add_dd_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_nsu_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add non service users columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
     dplyr::mutate("{prefix}" := dplyr::if_else(eval(condition), 1L, NA_integer_))
+
+   cli::cli_alert_info("Add non service users columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add NRS columns
@@ -508,12 +540,15 @@ add_nsu_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_nrs_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add nrs columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
     dplyr::mutate("{prefix}" := dplyr::if_else(eval(condition), 1L, NA_integer_))
+
+   cli::cli_alert_info("Add nrs columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add HL1 columns
@@ -521,11 +556,14 @@ add_nrs_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_hl1_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add homelessness columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition)
+
+    cli::cli_alert_info("Add homelessness columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add CH columns
@@ -533,10 +571,9 @@ add_hl1_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_ch_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add care home columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
     dplyr::mutate(
       ch_cost_per_day = dplyr::if_else(
@@ -558,6 +595,10 @@ add_ch_columns <- function(episode_file, prefix, condition) {
         .data$ch_ep_end
       )
     )
+
+  cli::cli_alert_info("Add care home columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add HC columns
@@ -565,7 +606,6 @@ add_ch_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_hc_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add home care columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
 
@@ -604,6 +644,10 @@ add_hc_columns <- function(episode_file, prefix, condition) {
       "{prefix}_reablement_hours" := dplyr::if_else(eval(condition_reabl), .data$hc_hours_annual, NA_real_),
       "{prefix}_reablement_hours_cost" := dplyr::if_else(eval(condition_reabl), .data$cost_total_net, NA_real_)
     )
+
+  cli::cli_alert_info("Add home care columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add AT columns
@@ -611,15 +655,18 @@ add_hc_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_at_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add alarms telecare columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
     dplyr::mutate(
       "{prefix}_alarms" := dplyr::if_else(eval(condition) & .data$smrtype == "AT-Alarm", 1L, NA_integer_),
       "{prefix}_telecare" := dplyr::if_else(eval(condition) & .data$smrtype == "AT-Tele", 1L, NA_integer_)
     )
+
+  cli::cli_alert_info("Add alarms telecare columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add SDS columns
@@ -627,10 +674,9 @@ add_at_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_sds_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add SDS columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
-  episode_file %>%
+  episode_file <- episode_file %>%
     add_standard_cols(prefix, condition) %>%
     dplyr::mutate(
       "{prefix}_option_1" := dplyr::if_else(eval(condition) & .data$smrtype == "SDS-1", 1L, NA_integer_),
@@ -638,6 +684,10 @@ add_sds_columns <- function(episode_file, prefix, condition) {
       "{prefix}_option_3" := dplyr::if_else(eval(condition) & .data$smrtype == "SDS-3", 1L, NA_integer_),
       "{prefix}_option_4" := dplyr::if_else(eval(condition) & .data$smrtype == "SDS-4", 1L, NA_integer_)
     )
+
+  cli::cli_alert_info("Add SDS columns function finished at {Sys.time()}")
+
+  return(episode_file)
 }
 
 #' Add columns based on IPDC
@@ -651,7 +701,6 @@ add_sds_columns <- function(episode_file, prefix, condition) {
 #' cij_pattype (lgl)
 #' @family individual_file
 add_ipdc_cols <- function(episode_file, prefix, condition, ipdc_d = TRUE, elective = TRUE) {
-  cli::cli_alert_info("Add ipdc columns function finished at {Sys.time()}")
 
   condition_i <- substitute(eval(condition) & ipdc == "I")
   episode_file <- episode_file %>%
@@ -684,6 +733,9 @@ add_ipdc_cols <- function(episode_file, prefix, condition, ipdc_d = TRUE, electi
         "{prefix}_daycase_cost" := dplyr::if_else(eval(condition_d), .data$cost_total_net, NA_real_)
       )
   }
+
+  cli::cli_alert_info("Add ipdc columns function finished at {Sys.time()}")
+
   return(episode_file)
 }
 
@@ -697,7 +749,7 @@ add_ipdc_cols <- function(episode_file, prefix, condition, ipdc_d = TRUE, electi
 #' @param cost Whether to create prefix_cost col, e.g. "Acute_cost"
 #' @family individual_file
 add_standard_cols <- function(episode_file, prefix, condition, episode = FALSE, cost = FALSE) {
-  cli::cli_alert_info("Add standard columns function finished at {Sys.time()}")
+
 
   if (episode) {
     episode_file <- dplyr::mutate(episode_file, "{prefix}_episodes" := dplyr::if_else(eval(condition), 1L, NA_integer_))
@@ -705,6 +757,9 @@ add_standard_cols <- function(episode_file, prefix, condition, episode = FALSE, 
   if (cost) {
     episode_file <- dplyr::mutate(episode_file, "{prefix}_cost" := dplyr::if_else(eval(condition), .data$cost_total_net, NA_real_))
   }
+
+  cli::cli_alert_info("Add standard columns function finished at {Sys.time()}")
+
   return(episode_file)
 }
 

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -18,7 +18,7 @@ create_individual_file <- function(
     write_to_disk = TRUE,
     anon_chi_in = TRUE,
     anon_chi_out = TRUE) {
-  cli::cli_alert_info("Create individual file function started at {Sys.time()}")
+  cli::cli_alert_info("Create individual file function finished at {Sys.time()}")
 
   if (anon_chi_in) {
     episode_file <- slfhelper::get_chi(
@@ -183,7 +183,7 @@ remove_blank_chi <- function(episode_file) {
     dplyr::mutate(chi = dplyr::na_if(.data$chi, "")) %>%
     dplyr::filter(!is.na(.data$chi))
 
-  cli::cli_alert_info("Remove blank CHI function started at {Sys.time()}")
+  cli::cli_alert_info("Remove blank CHI function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -224,7 +224,7 @@ add_cij_columns <- function(episode_file) {
       )
     )
 
-  cli::cli_alert_info("Add cij columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add cij columns function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -282,7 +282,7 @@ add_all_columns <- function(episode_file, year) {
       )
     )
 
-  cli::cli_alert_info("Add all columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add all columns function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -294,7 +294,7 @@ add_all_columns <- function(episode_file, year) {
 #' @param condition Condition to create new columns based on
 #' @family individual_file
 add_acute_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add acute columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add acute columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -307,7 +307,7 @@ add_acute_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_mat_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add maternity columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add maternity columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -320,7 +320,7 @@ add_mat_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_mh_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add mental health columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add mental health columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -333,7 +333,7 @@ add_mh_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_gls_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add geriatric long stay columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add geriatric long stay columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -346,7 +346,7 @@ add_gls_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_op_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add outpatient columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add outpatient columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file <- episode_file %>%
@@ -371,7 +371,7 @@ add_op_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_ae_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add A&E columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add A&E columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -384,7 +384,7 @@ add_ae_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_pis_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add prescribing columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add prescribing columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -397,7 +397,7 @@ add_pis_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_ooh_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add out of hours columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add out of hours columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file <- episode_file %>%
@@ -434,7 +434,7 @@ add_ooh_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_dn_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add district nursing columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add district nursing columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   if ("total_no_dn_contacts" %in% names(episode_file)) {
@@ -459,7 +459,7 @@ add_dn_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_cmh_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add communicty mental health columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add communicty mental health columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -472,7 +472,7 @@ add_cmh_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_dd_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add delayed discharges columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add delayed discharges columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   condition_delay <- substitute(condition & primary_delay_reason != "9")
@@ -495,7 +495,7 @@ add_dd_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_nsu_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add non service users columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add non service users columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -508,7 +508,7 @@ add_nsu_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_nrs_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add nrs columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add nrs columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -521,7 +521,7 @@ add_nrs_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_hl1_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add homelessness columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add homelessness columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -533,7 +533,7 @@ add_hl1_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_ch_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add care home columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add care home columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -565,7 +565,7 @@ add_ch_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_hc_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add home care columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add home care columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
 
@@ -611,7 +611,7 @@ add_hc_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_at_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add alarms telecare columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add alarms telecare columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -627,7 +627,7 @@ add_at_columns <- function(episode_file, prefix, condition) {
 #' @inheritParams add_acute_columns
 #' @family individual_file
 add_sds_columns <- function(episode_file, prefix, condition) {
-  cli::cli_alert_info("Add SDS columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add SDS columns function finished at {Sys.time()}")
 
   condition <- substitute(condition)
   episode_file %>%
@@ -651,7 +651,7 @@ add_sds_columns <- function(episode_file, prefix, condition) {
 #' cij_pattype (lgl)
 #' @family individual_file
 add_ipdc_cols <- function(episode_file, prefix, condition, ipdc_d = TRUE, elective = TRUE) {
-  cli::cli_alert_info("Add ipdc columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add ipdc columns function finished at {Sys.time()}")
 
   condition_i <- substitute(eval(condition) & ipdc == "I")
   episode_file <- episode_file %>%
@@ -697,7 +697,7 @@ add_ipdc_cols <- function(episode_file, prefix, condition, ipdc_d = TRUE, electi
 #' @param cost Whether to create prefix_cost col, e.g. "Acute_cost"
 #' @family individual_file
 add_standard_cols <- function(episode_file, prefix, condition, episode = FALSE, cost = FALSE) {
-  cli::cli_alert_info("Add standard columns function started at {Sys.time()}")
+  cli::cli_alert_info("Add standard columns function finished at {Sys.time()}")
 
   if (episode) {
     episode_file <- dplyr::mutate(episode_file, "{prefix}_episodes" := dplyr::if_else(eval(condition), 1L, NA_integer_))
@@ -748,7 +748,7 @@ clean_up_ch <- function(episode_file, year) {
     ) %>%
     dplyr::select(-c("fy_end", "fy_start", "term_1", "term_2"))
 
-  cli::cli_alert_info("Clean up CH function started at {Sys.time()}")
+  cli::cli_alert_info("Clean up CH function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -769,7 +769,7 @@ recode_gender <- function(episode_file) {
       )
     )
 
-  cli::cli_alert_info("Recode Gender function started at {Sys.time()}")
+  cli::cli_alert_info("Recode Gender function finished at {Sys.time()}")
 
   return(episode_file)
 }
@@ -785,7 +785,7 @@ condition_cols <- function() {
   date_cols <- paste0(conditions, "_date")
   all_cols <- c(conditions, date_cols)
 
-  cli::cli_alert_info("Return condition columns function started at {Sys.time()}")
+  cli::cli_alert_info("Return condition columns function finished at {Sys.time()}")
 
   return(all_cols)
 }
@@ -831,7 +831,7 @@ clean_individual_file <- function(individual_file, year) {
     clean_up_gender() %>%
     dplyr::mutate(age = compute_mid_year_age(year, .data$dob))
 
-  cli::cli_alert_info("Clean individual file function started at {Sys.time()}")
+  cli::cli_alert_info("Clean individual file function finished at {Sys.time()}")
 
   return(individual_file)
 }
@@ -850,7 +850,7 @@ clean_up_gender <- function(individual_file) {
       )
     )
 
-  cli::cli_alert_info("Clean up gender column function started at {Sys.time()}")
+  cli::cli_alert_info("Clean up gender column function finished at {Sys.time()}")
   return(individual_file)
 }
 
@@ -882,7 +882,7 @@ join_slf_lookup_vars <- function(individual_file,
     ) %>%
     dplyr::rename(hbrescode = hbrescode_var)
 
-  cli::cli_alert_info("Join slf lookup variables function started at {Sys.time()}")
+  cli::cli_alert_info("Join slf lookup variables function finished at {Sys.time()}")
 
   return(individual_file)
 }

--- a/R/fill_geographies.R
+++ b/R/fill_geographies.R
@@ -39,7 +39,7 @@ fill_geographies <- function(
       )
     )
 
-  cli::cli_alert_info("Fill geographies function started at {Sys.time()}")
+  cli::cli_alert_info("Fill geographies function finished at {Sys.time()}")
 
   return(data)
 }

--- a/R/fill_geographies.R
+++ b/R/fill_geographies.R
@@ -16,8 +16,6 @@ fill_geographies <- function(
       get_slf_gpprac_path(),
       col_select = c("gpprac", "cluster", "hbpraccode")
     )) {
-  cli::cli_alert_info("Fill geographies function started at {Sys.time()}")
-
   check_variables_exist(data, c(
     "chi",
     "postcode",
@@ -30,7 +28,7 @@ fill_geographies <- function(
     "gpprac"
   ))
 
-  data %>%
+  data <- data %>%
     fill_postcode_geogs(
       slf_pc_lookup = read_file(get_slf_postcode_path())
     ) %>%
@@ -40,6 +38,10 @@ fill_geographies <- function(
         col_select = c("gpprac", "cluster", "hbpraccode")
       )
     )
+
+  cli::cli_alert_info("Fill geographies function started at {Sys.time()}")
+
+  return(data)
 }
 
 #' Make a postcode lookup for filling to most recent postcodes based on CHI

--- a/R/join_deaths_data.R
+++ b/R/join_deaths_data.R
@@ -10,16 +10,16 @@ join_deaths_data <- function(
     data,
     year,
     slf_deaths_lookup = read_file(get_slf_deaths_lookup_path(year)) %>% slfhelper::get_chi()) {
+  data <- data %>%
+    dplyr::left_join(
+      slf_deaths_lookup %>%
+        dplyr::distinct(chi, .keep_all = TRUE),
+      by = "chi",
+      na_matches = "never",
+      relationship = "many-to-one"
+    )
+
   cli::cli_alert_info("Join deaths data function started at {Sys.time()}")
 
-  return(
-    data %>%
-      dplyr::left_join(
-        slf_deaths_lookup %>%
-          dplyr::distinct(chi, .keep_all = TRUE),
-        by = "chi",
-        na_matches = "never",
-        relationship = "many-to-one"
-      )
-  )
+  return(data)
 }

--- a/R/join_deaths_data.R
+++ b/R/join_deaths_data.R
@@ -19,7 +19,7 @@ join_deaths_data <- function(
       relationship = "many-to-one"
     )
 
-  cli::cli_alert_info("Join deaths data function started at {Sys.time()}")
+  cli::cli_alert_info("Join deaths data function finished at {Sys.time()}")
 
   return(data)
 }

--- a/R/join_sparra_hhg.R
+++ b/R/join_sparra_hhg.R
@@ -61,7 +61,7 @@ join_sparra_hhg <- function(data, year) {
     data <- dplyr::mutate(data, hhg_end_fy = NA_integer_)
   }
 
-  cli::cli_alert_info("Join SPARRA and HHG function started at {Sys.time()}")
+  cli::cli_alert_info("Join SPARRA and HHG function finished at {Sys.time()}")
 
   return(data)
 }

--- a/R/join_sparra_hhg.R
+++ b/R/join_sparra_hhg.R
@@ -5,8 +5,6 @@
 #' @return The data including the SPARRA and HHG variables matched
 #' on to the episode file.
 join_sparra_hhg <- function(data, year) {
-  cli::cli_alert_info("Join SPARRA and HHG function started at {Sys.time()}")
-
   if (check_year_valid(year, "sparra")) {
     data <- dplyr::left_join(
       data,
@@ -62,6 +60,8 @@ join_sparra_hhg <- function(data, year) {
   } else {
     data <- dplyr::mutate(data, hhg_end_fy = NA_integer_)
   }
+
+  cli::cli_alert_info("Join SPARRA and HHG function started at {Sys.time()}")
 
   return(data)
 }

--- a/R/link_delayed_discharge_eps.R
+++ b/R/link_delayed_discharge_eps.R
@@ -12,8 +12,6 @@ link_delayed_discharge_eps <- function(
     episode_file,
     year,
     dd_data = read_file(get_source_extract_path(year, "dd")) %>% slfhelper::get_chi()) {
-  cli::cli_alert_info("Link delayed discharge to episode file function started at {Sys.time()}")
-
   if (!check_year_valid(year, type = "dd")) {
     episode_file <- episode_file
     return(episode_file)
@@ -375,6 +373,8 @@ link_delayed_discharge_eps <- function(
       cij_delay
     )) %>%
     dplyr::select(-c("has_dd", "delay_dd", "original_admission_date", "amended_dates"))
+
+  cli::cli_alert_info("Link delayed discharge to episode file function started at {Sys.time()}")
 
   return(linked_data)
 }

--- a/R/link_delayed_discharge_eps.R
+++ b/R/link_delayed_discharge_eps.R
@@ -374,7 +374,7 @@ link_delayed_discharge_eps <- function(
     )) %>%
     dplyr::select(-c("has_dd", "delay_dd", "original_admission_date", "amended_dates"))
 
-  cli::cli_alert_info("Link delayed discharge to episode file function started at {Sys.time()}")
+  cli::cli_alert_info("Link delayed discharge to episode file function finished at {Sys.time()}")
 
   return(linked_data)
 }

--- a/R/match_on_ltcs.R
+++ b/R/match_on_ltcs.R
@@ -30,7 +30,7 @@ match_on_ltcs <- function(
     ) %>%
     dplyr::select(-tidyselect::ends_with("_ltc"))
 
-  cli::cli_alert_info("Match on LTCs function started at {Sys.time()}")
+  cli::cli_alert_info("Match on LTCs function finished at {Sys.time()}")
 
   return(matched)
 }

--- a/R/match_on_ltcs.R
+++ b/R/match_on_ltcs.R
@@ -12,8 +12,6 @@ match_on_ltcs <- function(
     data,
     year,
     ltc_data = read_file(get_ltcs_path(year)) %>% slfhelper::get_chi()) {
-  cli::cli_alert_info("Match on LTCs function started at {Sys.time()}")
-
   # Match on LTC lookup
   matched <- dplyr::left_join(
     data,
@@ -31,6 +29,8 @@ match_on_ltcs <- function(
       )
     ) %>%
     dplyr::select(-tidyselect::ends_with("_ltc"))
+
+  cli::cli_alert_info("Match on LTCs function started at {Sys.time()}")
 
   return(matched)
 }

--- a/R/process_lookup_homelessness.R
+++ b/R/process_lookup_homelessness.R
@@ -41,8 +41,6 @@ create_homelessness_lookup <- function(
 #' @export
 add_homelessness_flag <- function(data, year,
                                   lookup = create_homelessness_lookup(year)) {
-  cli::cli_alert_info("Add homelessness flag function started at {Sys.time()}")
-
   if (!check_year_valid(year, type = "homelessness")) {
     data <- data
     return(data)
@@ -56,6 +54,8 @@ add_homelessness_flag <- function(data, year,
       relationship = "many-to-one"
     ) %>%
     dplyr::mutate(hl1_in_fy = tidyr::replace_na(.data$hl1_in_fy, 0L))
+
+  cli::cli_alert_info("Add homelessness flag function started at {Sys.time()}")
 
   return(data)
 }
@@ -72,8 +72,6 @@ add_homelessness_flag <- function(data, year,
 #' @return the final data as a [tibble][tibble::tibble-package].
 #' @export
 add_homelessness_date_flags <- function(data, year, lookup = create_homelessness_lookup(year)) {
-  cli::cli_alert_info("Add homelessness date flags function started at {Sys.time()}")
-
   if (!check_year_valid(year, type = "homelessness")) {
     data <- data
     return(data)
@@ -132,6 +130,8 @@ add_homelessness_date_flags <- function(data, year, lookup = create_homelessness
         roll_to_first = TRUE
       )
     )
+
+  cli::cli_alert_info("Add homelessness date flags function started at {Sys.time()}")
 
   return(data)
 }

--- a/R/process_lookup_homelessness.R
+++ b/R/process_lookup_homelessness.R
@@ -22,7 +22,7 @@ create_homelessness_lookup <- function(
     tidyr::drop_na(.data$chi) %>%
     dplyr::mutate(hl1_in_fy = 1L)
 
-  cli::cli_alert_info("Create homelessness lookup function started at {Sys.time()}")
+  cli::cli_alert_info("Create homelessness lookup function finished at {Sys.time()}")
 
   return(homelessness_lookup)
 }
@@ -55,7 +55,7 @@ add_homelessness_flag <- function(data, year,
     ) %>%
     dplyr::mutate(hl1_in_fy = tidyr::replace_na(.data$hl1_in_fy, 0L))
 
-  cli::cli_alert_info("Add homelessness flag function started at {Sys.time()}")
+  cli::cli_alert_info("Add homelessness flag function finished at {Sys.time()}")
 
   return(data)
 }
@@ -131,7 +131,7 @@ add_homelessness_date_flags <- function(data, year, lookup = create_homelessness
       )
     )
 
-  cli::cli_alert_info("Add homelessness date flags function started at {Sys.time()}")
+  cli::cli_alert_info("Add homelessness date flags function finished at {Sys.time()}")
 
   return(data)
 }

--- a/R/process_lookup_homelessness.R
+++ b/R/process_lookup_homelessness.R
@@ -13,8 +13,6 @@
 create_homelessness_lookup <- function(
     year,
     homelessness_data = read_file(get_source_extract_path(year, "homelessness")) %>% slfhelper::get_chi()) {
-  cli::cli_alert_info("Create homelessness lookup function started at {Sys.time()}")
-
   # Specify years available for running
   if (year < "1617") {
     return(NULL)
@@ -23,6 +21,8 @@ create_homelessness_lookup <- function(
     dplyr::distinct(.data$chi, .data$record_keydate1, .data$record_keydate2) %>%
     tidyr::drop_na(.data$chi) %>%
     dplyr::mutate(hl1_in_fy = 1L)
+
+  cli::cli_alert_info("Create homelessness lookup function started at {Sys.time()}")
 
   return(homelessness_lookup)
 }


### PR DESCRIPTION
Closes #1010 

I've looked through all functions for `create_episode_file` and `create_individual_file` and moved the cli messages before the `return()`