### PR TITLE
Bug - round hl1 completeness flag to 2 dp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# June 2025 update - Unreleased 
+* HL1 completeness flag adjusted to 2 decimal places. 
+* Scottish postcode directory updated
+
 # March 2025 Update - released 05-Mar-25
 * 24/25 files have been updated, containing data up to December 2024.
 * 17/18 - 23/24 files have been updated.

--- a/R/process_extract_homelessness.R
+++ b/R/process_extract_homelessness.R
@@ -152,7 +152,7 @@ process_extract_homelessness <- function(
       by = dplyr::join_by("sending_local_authority_name")
     ) %>%
     dplyr::rename(hl1_completeness = "pct_complete_all") %>%
-    dplyr::mutate(hl1_completeness = round(.data$hl1_completeness, 1))
+    dplyr::mutate(hl1_completeness = round(.data$hl1_completeness, 2))
 
   final_data <- hl1_data %>%
     dplyr::select(


### PR DESCRIPTION
Following feedback from the homelessness team, we have adjusted the `hl1_completeness_flag` to two decimal places. 

closes #1055