### PR TITLE
Check hscdiip/sourcedev permissions

### DIFF
--- a/Pre_processing_scripts/01_Sort_IT_Extracts.R
+++ b/Pre_processing_scripts/01_Sort_IT_Extracts.R
@@ -72,7 +72,7 @@ convert_it_csv_to_parquet <- function(csv_file) {
       ) %>%
       slfhelper::get_anon_chi()
   }
-  write_file(data, new_file)
+  write_file(data, new_file, group_id = 3206) # hscdiip owner
   cli::cli_alert_info("\n {basename(csv_file)} finished at {Sys.time()}")
 }
 

--- a/Pre_processing_scripts/copy_to_hscdiip.R
+++ b/Pre_processing_scripts/copy_to_hscdiip.R
@@ -33,7 +33,7 @@ for (i in 1:year_n) {
     overwrite = TRUE
   )
   fs::file_move(new_path_im, new_path)
-  fs::file_chmod(new_path, mode = "640")
+  fs::file_chmod(new_path, mode = "770")
 
   resource_consumption$time_consumption[i] <- (Sys.time() - timer)
   file_size <- sum(file.size(old_path)) / 2^20

--- a/Pre_processing_scripts/write_anon_chi_files.R
+++ b/Pre_processing_scripts/write_anon_chi_files.R
@@ -42,12 +42,12 @@ for (data_file in parquet_files) {
   if (chi_in_file) {
     read_file(data_file) %>%
       slfhelper::get_anon_chi() %>%
-      write_file(save_file_path)
+      write_file(save_file_path, group_id = 3206) # hscdiip owner
 
     cat("Replaced chi with anon chi:", data_file, "to", save_file_path, "\n")
   } else {
     read_file(data_file) %>%
-      write_file(save_file_path)
+      write_file(save_file_path, group_id = 3206) # hscdiip owner
     cat("renamed file with anon chi:", data_file, "to", save_file_path, "\n")
   }
 }

--- a/R/create_demographic_lookup.R
+++ b/R/create_demographic_lookup.R
@@ -173,7 +173,8 @@ create_demographic_cohorts <- function(
   # Write to disk
   if (write_to_disk) {
     write_file(demo_lookup,
-      path = get_demographic_cohorts_path(year, update, check_mode = "write")
+      path = get_demographic_cohorts_path(year, update, check_mode = "write"),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/create_episode_file.R
+++ b/R/create_episode_file.R
@@ -258,7 +258,9 @@ create_episode_file <- function(
   }
 
   if (write_to_disk) {
-    write_file(episode_file, get_slf_episode_path(year, check_mode = "write"))
+    write_file(episode_file, get_slf_episode_path(year, check_mode = "write"),
+      group_id = 3356
+    ) # sourcedev owner
   }
 
   return(episode_file)
@@ -292,7 +294,8 @@ store_ep_file_vars <- function(data, year, vars_to_keep) {
     dplyr::all_of(vars_to_store)
   ) %>%
     write_file(
-      path = tempfile_path
+      path = tempfile_path,
+      group_id = 3356 # sourcedev owner
     )
 
   cli::cli_alert_info("Store episode file variables function finished at {Sys.time()}")

--- a/R/create_individual_file.R
+++ b/R/create_individual_file.R
@@ -157,7 +157,7 @@ create_individual_file <- function(
   if (write_to_disk) {
     slf_indiv_path <- get_slf_individual_path(year, check_mode = "write")
 
-    write_file(individual_file, slf_indiv_path)
+    write_file(individual_file, slf_indiv_path, group_id = 3356) # sourcedev owner
   }
 
   return(individual_file)

--- a/R/create_service_use_lookup.R
+++ b/R/create_service_use_lookup.R
@@ -258,7 +258,8 @@ create_service_use_cohorts <- function(
 
   if (write_to_disk) {
     write_file(return_data,
-      path = get_service_use_cohorts_path(year, update, check_mode = "write")
+      path = get_service_use_cohorts_path(year, update, check_mode = "write"),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/get_gpprac_opendata.R
+++ b/R/get_gpprac_opendata.R
@@ -32,7 +32,9 @@ get_gpprac_opendata <- function() {
       postcode = phsmethods::format_postcode(.data$postcode)
     ) %>%
     dplyr::distinct(.data$gpprac, .keep_all = TRUE) %>%
-    write_file(get_practice_details_path(check_mode = "write"))
+    write_file(get_practice_details_path(check_mode = "write"),
+      group_id = 3206
+    ) # hscdiip owner
 
   return(gpprac_data)
 }

--- a/R/process_costs_rmd.R
+++ b/R/process_costs_rmd.R
@@ -60,8 +60,11 @@ process_costs_rmd <- function(file_name) {
   }
 
   if (fs::file_info(output_file)$user == Sys.getenv("USER")) {
-    # Set the correct permissions
-    fs::file_chmod(path = output_file, mode = "660")
+    # Set the correct permissions (read, write, execute)
+    fs::file_chmod(path = output_file, mode = "770")
+    # change the owner so that hscdiip is the group owner.
+    # use fs::group_ids() for checking
+    fs::file_chown(path = output_file, group_id = 3206)
   }
 
   utils::browseURL(output_file)

--- a/R/process_extract_acute.R
+++ b/R/process_extract_acute.R
@@ -164,7 +164,8 @@ process_extract_acute <- function(data,
   if (write_to_disk) {
     write_file(
       acute_processed,
-      get_source_extract_path(year, "acute", check_mode = "write")
+      get_source_extract_path(year, "acute", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_ae.R
+++ b/R/process_extract_ae.R
@@ -310,7 +310,8 @@ process_extract_ae <- function(data, year, write_to_disk = TRUE) {
   if (write_to_disk) {
     write_file(
       ae_processed,
-      get_source_extract_path(year, "ae", check_mode = "write")
+      get_source_extract_path(year, "ae", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_alarms_telecare.R
+++ b/R/process_extract_alarms_telecare.R
@@ -52,7 +52,8 @@ process_extract_alarms_telecare <- function(
   if (write_to_disk) {
     at_data %>%
       write_file(
-        get_source_extract_path(year, type = "at", check_mode = "write")
+        get_source_extract_path(year, type = "at", check_mode = "write"),
+        group_id = 3356 # sourcedev owner
       )
   }
 

--- a/R/process_extract_care_home.R
+++ b/R/process_extract_care_home.R
@@ -133,7 +133,8 @@ process_extract_care_home <- function(
   if (write_to_disk) {
     write_file(
       ch_processed,
-      get_source_extract_path(year, type = "ch", check_mode = "write")
+      get_source_extract_path(year, type = "ch", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_cmh.R
+++ b/R/process_extract_cmh.R
@@ -73,7 +73,8 @@ process_extract_cmh <- function(data,
   if (write_to_disk) {
     write_file(
       cmh_processed,
-      get_source_extract_path(year, "cmh", check_mode = "write")
+      get_source_extract_path(year, "cmh", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_delayed_discharges.R
+++ b/R/process_extract_delayed_discharges.R
@@ -110,7 +110,8 @@ process_extract_delayed_discharges <- function(
   if (write_to_disk) {
     write_file(
       dd_final,
-      get_source_extract_path(year, "dd", check_mode = "write")
+      get_source_extract_path(year, "dd", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_district_nursing.R
+++ b/R/process_extract_district_nursing.R
@@ -139,7 +139,9 @@ process_extract_district_nursing <- function(
 
   if (write_to_disk) {
     dn_episodes %>%
-      write_file(get_source_extract_path(year, "dn", check_mode = "write"))
+      write_file(get_source_extract_path(year, "dn", check_mode = "write"),
+        group_id = 3356
+      ) # sourcedev owner
   }
 
   return(dn_episodes)

--- a/R/process_extract_gp_ooh.R
+++ b/R/process_extract_gp_ooh.R
@@ -165,7 +165,9 @@ process_extract_gp_ooh <- function(year,
 
   if (write_to_disk) {
     final_data %>%
-      write_file(get_source_extract_path(year, "gp_ooh", check_mode = "write"))
+      write_file(get_source_extract_path(year, "gp_ooh", check_mode = "write"),
+        group_id = 3356
+      ) # sourcedev owner
   }
 
   return(final_data)

--- a/R/process_extract_home_care.R
+++ b/R/process_extract_home_care.R
@@ -101,7 +101,8 @@ process_extract_home_care <- function(
   if (write_to_disk) {
     write_file(
       hc_processed,
-      get_source_extract_path(year, type = "hc", check_mode = "write")
+      get_source_extract_path(year, type = "hc", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_homelessness.R
+++ b/R/process_extract_homelessness.R
@@ -180,7 +180,8 @@ process_extract_homelessness <- function(
         year = year,
         type = "homelessness",
         check_mode = "write"
-      )
+      ),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_maternity.R
+++ b/R/process_extract_maternity.R
@@ -117,7 +117,8 @@ process_extract_maternity <- function(data, year, write_to_disk = TRUE) {
   if (write_to_disk) {
     write_file(
       maternity_processed,
-      get_source_extract_path(year, "maternity", check_mode = "write")
+      get_source_extract_path(year, "maternity", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_mental_health.R
+++ b/R/process_extract_mental_health.R
@@ -122,7 +122,8 @@ process_extract_mental_health <- function(data, year, write_to_disk = TRUE) {
   if (write_to_disk) {
     write_file(
       mh_processed,
-      get_source_extract_path(year, "mh", check_mode = "write")
+      get_source_extract_path(year, "mh", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_nrs_deaths.R
+++ b/R/process_extract_nrs_deaths.R
@@ -27,7 +27,9 @@ process_extract_nrs_deaths <- function(data, year, write_to_disk = TRUE) {
 
   if (write_to_disk) {
     deaths_clean %>%
-      write_file(get_source_extract_path(year, "deaths", check_mode = "write"))
+      write_file(get_source_extract_path(year, "deaths", check_mode = "write"),
+        group_id = 3356 # sourcedev owner
+      )
   }
 
   return(deaths_clean)

--- a/R/process_extract_outpatients.R
+++ b/R/process_extract_outpatients.R
@@ -93,7 +93,8 @@ process_extract_outpatients <- function(data, year, write_to_disk = TRUE) {
   if (write_to_disk) {
     write_file(
       outpatients_processed,
-      get_source_extract_path(year, "outpatients", check_mode = "write")
+      get_source_extract_path(year, "outpatients", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_prescribing.R
+++ b/R/process_extract_prescribing.R
@@ -55,7 +55,8 @@ process_extract_prescribing <- function(data, year, write_to_disk = TRUE) {
   if (write_to_disk) {
     write_file(
       pis_clean,
-      get_source_extract_path(year, "pis", check_mode = "write")
+      get_source_extract_path(year, "pis", check_mode = "write"),
+      group_id = 3356 # sourcedev owner
     )
   }
 

--- a/R/process_extract_sds.R
+++ b/R/process_extract_sds.R
@@ -51,7 +51,9 @@ process_extract_sds <- function(
 
   if (write_to_disk) {
     outfile %>%
-      write_file(get_source_extract_path(year, type = "sds", check_mode = "write"))
+      write_file(get_source_extract_path(year, type = "sds", check_mode = "write"),
+        group_id = 3356 # sourcedev owner
+      )
   }
 
   return(outfile)

--- a/R/process_it_chi_deaths.R
+++ b/R/process_it_chi_deaths.R
@@ -26,7 +26,9 @@ process_it_chi_deaths <- function(data, write_to_disk = TRUE) {
 
   if (write_to_disk) {
     it_chi_deaths_clean %>%
-      write_file(get_slf_chi_deaths_path(check_mode = "write"))
+      write_file(get_slf_chi_deaths_path(check_mode = "write"),
+        group_id = 3206 # hscdiip owner
+      )
   }
 
   return(it_chi_deaths_clean)

--- a/R/process_lookup_deaths.R
+++ b/R/process_lookup_deaths.R
@@ -26,7 +26,8 @@ process_slf_deaths_lookup <- function(
   if (write_to_disk) {
     write_file(
       slf_deaths_lookup,
-      get_slf_deaths_lookup_path(year, check_mode = "write")
+      get_slf_deaths_lookup_path(year, check_mode = "write"),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/process_lookup_gpprac.R
+++ b/R/process_lookup_gpprac.R
@@ -76,7 +76,9 @@ process_lookup_gpprac <- function(
 
   if (write_to_disk) {
     gpprac_slf_lookup %>%
-      write_file(get_slf_gpprac_path(check_mode = "write"))
+      write_file(get_slf_gpprac_path(check_mode = "write"),
+        group_id = 3206 # hscdiip owner
+      )
   }
 
   return(gpprac_slf_lookup)

--- a/R/process_lookup_ltc.R
+++ b/R/process_lookup_ltc.R
@@ -27,7 +27,8 @@ process_lookup_ltc <- function(data, year, write_to_disk = TRUE) {
   if (write_to_disk) {
     write_file(
       ltc_flags,
-      get_ltcs_path(year, check_mode = "write")
+      get_ltcs_path(year, check_mode = "write"),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/process_lookup_postcode.R
+++ b/R/process_lookup_postcode.R
@@ -91,7 +91,8 @@ process_lookup_postcode <- function(spd_path = get_spd_path(),
   if (write_to_disk) {
     write_file(
       slf_pc_lookup,
-      get_slf_postcode_path(check_mode = "write")
+      get_slf_postcode_path(check_mode = "write"),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/process_lookup_sc_client.R
+++ b/R/process_lookup_sc_client.R
@@ -205,7 +205,8 @@ process_lookup_sc_client <-
     if (write_to_disk) {
       write_file(
         sc_client_lookup,
-        get_sc_client_lookup_path(year, check_mode = "write")
+        get_sc_client_lookup_path(year, check_mode = "write"),
+        group_id = 3206 # hscdiip owner
       )
     }
 

--- a/R/process_lookup_sc_demographics.R
+++ b/R/process_lookup_sc_demographics.R
@@ -149,7 +149,8 @@ process_lookup_sc_demographics <- function(
   if (write_to_disk) {
     write_file(
       sc_demog_lookup,
-      get_sc_demog_lookup_path(check_mode = "write")
+      get_sc_demog_lookup_path(check_mode = "write"),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/process_refined_death.R
+++ b/R/process_refined_death.R
@@ -60,7 +60,8 @@ process_refined_death <- function(
   if (write_to_disk) {
     write_file(
       refined_death,
-      get_combined_slf_deaths_lookup_path(create = TRUE)
+      get_combined_slf_deaths_lookup_path(create = TRUE),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/process_sc_all_alarms_telecare.R
+++ b/R/process_sc_all_alarms_telecare.R
@@ -135,7 +135,8 @@ process_sc_all_alarms_telecare <- function(
   if (write_to_disk) {
     write_file(
       qtr_merge,
-      get_sc_at_episodes_path(check_mode = "write")
+      get_sc_at_episodes_path(check_mode = "write"),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/process_sc_all_care_home.R
+++ b/R/process_sc_all_care_home.R
@@ -454,7 +454,9 @@ process_sc_all_care_home <- function(
 
   if (write_to_disk) {
     ch_data_final %>%
-      write_file(get_sc_ch_episodes_path(check_mode = "write"))
+      write_file(get_sc_ch_episodes_path(check_mode = "write"),
+        group_id = 3206 # hscdiip owner
+      )
   }
 
   return(ch_data_final)

--- a/R/process_sc_all_home_care.R
+++ b/R/process_sc_all_home_care.R
@@ -202,7 +202,8 @@ process_sc_all_home_care <- function(
   if (write_to_disk) {
     write_file(
       all_hc_processed,
-      get_sc_hc_episodes_path(check_mode = "write")
+      get_sc_hc_episodes_path(check_mode = "write"),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/process_sc_all_sds.R
+++ b/R/process_sc_all_sds.R
@@ -182,7 +182,8 @@ process_sc_all_sds <- function(
   if (write_to_disk) {
     write_file(
       final_data,
-      get_sc_sds_episodes_path(check_mode = "write")
+      get_sc_sds_episodes_path(check_mode = "write"),
+      group_id = 3206 # hscdiip owner
     )
   }
 

--- a/R/produce_homelessness_completeness.R
+++ b/R/produce_homelessness_completeness.R
@@ -103,7 +103,8 @@ produce_homelessness_completeness <- function(
       year = year,
       update = update,
       check_mode = "write"
-    )
+    ),
+    group_id = 3206 # hscdiip owner
   )
 
   return(annual_comparison)

--- a/R/read_lookup_sc_client.R
+++ b/R/read_lookup_sc_client.R
@@ -88,7 +88,9 @@ read_lookup_sc_client <- function(fyyear,
 
   if (!fs::file_exists(get_sandpit_extract_path(type = "client", year = fyyear))) {
     client_data %>%
-      write_file(get_sandpit_extract_path(type = "client", year = fyyear))
+      write_file(get_sandpit_extract_path(type = "client", year = fyyear),
+        group_id = 3206 # hscdiip owner
+      )
 
     client_data %>%
       process_tests_sc_sandpit(type = "client", year = fyyear)

--- a/R/read_lookup_sc_demographics.R
+++ b/R/read_lookup_sc_demographics.R
@@ -36,7 +36,9 @@ read_lookup_sc_demographics <- function(sc_dvprod_connection = phs_db_connection
 
   if (!fs::file_exists(get_sandpit_extract_path(type = "demographics"))) {
     sc_demog %>%
-      write_file(get_sandpit_extract_path(type = "demographics"))
+      write_file(get_sandpit_extract_path(type = "demographics"),
+        group_id = 3206 # hscdiip owner
+      )
 
     sc_demog %>%
       process_tests_sc_sandpit(type = "demographics")

--- a/R/read_sc_all_alarms_telecare.R
+++ b/R/read_sc_all_alarms_telecare.R
@@ -36,7 +36,9 @@ read_sc_all_alarms_telecare <- function(sc_dvprod_connection = phs_db_connection
 
   if (!fs::file_exists(get_sandpit_extract_path(type = "at"))) {
     at_full_data %>%
-      write_file(get_sandpit_extract_path(type = "at"))
+      write_file(get_sandpit_extract_path(type = "at"),
+        group_id = 3206 # hscdiip owner
+      )
 
     at_full_data %>%
       process_tests_sc_sandpit(type = "at")

--- a/R/read_sc_all_care_home.R
+++ b/R/read_sc_all_care_home.R
@@ -39,7 +39,9 @@ read_sc_all_care_home <- function(sc_dvprod_connection = phs_db_connection(dsn =
 
   if (!fs::file_exists(get_sandpit_extract_path(type = "ch"))) {
     ch_data %>%
-      write_file(get_sandpit_extract_path(type = "ch"))
+      write_file(get_sandpit_extract_path(type = "ch"),
+        group_id = 3206 # hscdiip owner
+      )
 
     ch_data %>%
       process_tests_sc_sandpit(type = "ch")

--- a/R/read_sc_all_home_care.R
+++ b/R/read_sc_all_home_care.R
@@ -55,7 +55,9 @@ read_sc_all_home_care <- function(sc_dvprod_connection = phs_db_connection(dsn =
 
   if (!fs::file_exists(get_sandpit_extract_path(type = "hc"))) {
     home_care_data %>%
-      write_file(get_sandpit_extract_path(type = "hc"))
+      write_file(get_sandpit_extract_path(type = "hc"),
+        group_id = 3206 # hscdiip owner
+      )
 
     home_care_data %>%
       process_tests_sc_sandpit(type = "hc")

--- a/R/read_sc_all_sds.R
+++ b/R/read_sc_all_sds.R
@@ -36,7 +36,9 @@ read_sc_all_sds <- function(sc_dvprod_connection = phs_db_connection(dsn = "DVPR
 
   if (!fs::file_exists(get_sandpit_extract_path(type = "sds"))) {
     sds_full_data %>%
-      write_file(get_sandpit_extract_path(type = "sds"))
+      write_file(get_sandpit_extract_path(type = "sds"),
+        group_id = 3206 # hscdiip owner
+      )
 
     sds_full_data %>%
       process_tests_sc_sandpit(type = "sds")

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -47,7 +47,6 @@ write_file <- function(data, path, ...) {
     # change the owner so that sourcedev is the group owner.
     # use fs::group_ids() for checking
     fs::file_chown(path = path, group_id = 3356)
-
   }
 
   return(invisible(data))

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -7,11 +7,13 @@
 #'
 #' @param data The data to be written
 #' @param path The file path to be write
+#' @param group_id The group id for setting permissions. The default is 3356 for
+#'            sourcedev. To set this to hscdiip, use 3206.
 #' @param ... Additional arguments passed to the relevant function.
 #'
 #' @return the data (invisibly) as a [tibble][tibble::tibble-package].
 #' @export
-write_file <- function(data, path, ...) {
+write_file <- function(data, path, group_id = 3356, ...) {
   valid_extensions <- c("rds", "parquet")
 
   ext <- fs::path_ext(path)
@@ -46,7 +48,7 @@ write_file <- function(data, path, ...) {
     fs::file_chmod(path = path, mode = "770")
     # change the owner so that sourcedev is the group owner.
     # use fs::group_ids() for checking
-    fs::file_chown(path = path, group_id = 3356)
+    fs::file_chown(path = path, group_id = group_id)
   }
 
   return(invisible(data))

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -42,8 +42,12 @@ write_file <- function(data, path, ...) {
   )
 
   if (fs::file_info(path)$user == Sys.getenv("USER")) {
-    # Set the correct permissions
-    fs::file_chmod(path = path, mode = "660")
+    # Set the correct permissions (read, write, execute)
+    fs::file_chmod(path = path, mode = "770")
+    # change the owner so that sourcedev is the group owner.
+    # use fs::group_ids() for checking
+    fs::file_chown(path = path, group_id = 3356)
+
   }
 
   return(invisible(data))

--- a/R/write_temp_data.R
+++ b/R/write_temp_data.R
@@ -18,7 +18,8 @@ write_temp_data <-
       )
 
       write_file(data,
-        path = file_path
+        path = file_path,
+        group_id = 3356 # sourcedev owner
       )
       cli::cli_alert_info(stringr::str_glue("Writing {full_file_name} to disk finished at {Sys.time()}"))
     }

--- a/R/write_tests_xlsx.R
+++ b/R/write_tests_xlsx.R
@@ -293,8 +293,11 @@ write_tests_xlsx <- function(comparison_data,
   )
 
   if (fs::file_info(path = tests_workbook_path)$user == Sys.getenv("USER")) {
-    # Set the correct permissions
-    fs::file_chmod(path = tests_workbook_path, mode = "660")
+    # Set the correct permissions (read, write, execute)
+    fs::file_chmod(path = tests_workbook_path, mode = "770")
+    # change the owner so that hscdiip is the group owner.
+    # use fs::group_ids() for checking
+    fs::file_chown(path = tests_workbook_path, group_id = 3206)
   }
 
   fs::file_delete(path = in_use_path)

--- a/Rmarkdown/costs_care_home.Rmd
+++ b/Rmarkdown/costs_care_home.Rmd
@@ -123,7 +123,9 @@ matched_costs_data %>%
 
 # Save .rds file
 ch_costs_uplifted %>%
-  write_file(get_ch_costs_path(check_mode = "write"))
+  write_file(get_ch_costs_path(check_mode = "write"),
+    group_id = 3206 # hscdiip owner
+  )
 ```
 
 # Graph showing the cost difference between new and old costs 
@@ -145,4 +147,3 @@ ggplot(
   scale_colour_discrete() +
   labs(y = "Cost per day", color = "Nursing Care provision")
 ```
-

--- a/Rmarkdown/costs_district_nursing.Rmd
+++ b/Rmarkdown/costs_district_nursing.Rmd
@@ -206,7 +206,9 @@ outfile <-
 
 outfile %>%
   # Save .rds file
-  write_file(get_dn_costs_path(check_mode = "write"))
+  write_file(get_dn_costs_path(check_mode = "write"),
+    group_id = 3206 # hscdiip owner
+  )
 ```
 
 # Graph showing the number of contacts

--- a/Rmarkdown/costs_gp_ooh.Rmd
+++ b/Rmarkdown/costs_gp_ooh.Rmd
@@ -83,7 +83,9 @@ matched_costs_data <- gp_ooh_costs_uplifted %>%
 gp_ooh_costs_uplifted %>%
   dplyr::rename(TreatmentNHSBoardCode = "HB2019") %>%
   # Save .rds file
-  write_file(get_gp_ooh_costs_path(check_mode = "write"))
+  write_file(get_gp_ooh_costs_path(check_mode = "write"),
+    group_id = 3206 # hscdiip owner
+  )
 ```
 
 # Graph showing the cost difference 

--- a/Rmarkdown/costs_home_care.Rmd
+++ b/Rmarkdown/costs_home_care.Rmd
@@ -89,7 +89,9 @@ matched_costs_data <- hc_costs_uplifted %>%
 outfile <- hc_costs_uplifted %>%
   select(-health_board) %>%
   # Save .rds file
-  write_file(get_hc_costs_path(check_mode = "write"))
+  write_file(get_hc_costs_path(check_mode = "write"),
+    group_id = 3206 # hscdiip owner
+  )
 ```
 
 

--- a/man/write_file.Rd
+++ b/man/write_file.Rd
@@ -4,12 +4,15 @@
 \alias{write_file}
 \title{Write a data to a file}
 \usage{
-write_file(data, path, ...)
+write_file(data, path, group_id = 3356, ...)
 }
 \arguments{
 \item{data}{The data to be written}
 
 \item{path}{The file path to be write}
+
+\item{group_id}{The group id for setting permissions. The default is 3356 for
+sourcedev. To set this to hscdiip, use 3206.}
 
 \item{...}{Additional arguments passed to the relevant function.}
 }


### PR DESCRIPTION
closes #1072 

Fixes a bug we commonly see when running the SLFs. When one analyst creates the episode/dev files these give ownership permissions to the analyst, but when another analyst tries to overwrite the file, they get permission denied. This fix should solve this and allow another analyst who is not the owner, overwrite the files. 