### PR TITLE
SC - Update to client extraction from platform

### DIFF
--- a/R/read_lookup_sc_client.R
+++ b/R/read_lookup_sc_client.R
@@ -14,8 +14,21 @@ read_lookup_sc_client <- function(fyyear,
   check_year_format(fyyear)
   year <- convert_fyyear_to_year(fyyear)
 
-  # read in data - social care 2 client
-  client_data <- dplyr::tbl(sc_dvprod_connection, dbplyr::in_schema("social_care_2", "client")) %>%
+
+  # extract fy client data
+  client_fy_extract <- dplyr::tbl(sc_dvprod_connection, dbplyr::in_schema("social_care_2", "client_fy_snapshot")) %>%
+    dplyr::filter(.data$financial_year == year) %>%
+    dplyr::collect()
+
+  # extract qtr client data
+  client_qtr_extract <- dplyr::tbl(sc_dvprod_connection, dbplyr::in_schema("social_care_2", "client_qtr_snapshot")) %>%
+    dplyr::filter(.data$financial_year == year) %>%
+    dplyr::collect()
+
+  # Bind client FY and QTR extracts together
+  client_extract <- rbind(client_fy_extract, client_qtr_extract)
+
+  client_data <- client_extract %>%
     dplyr::select(
       "sending_location",
       "social_care_id",

--- a/R/read_lookup_sc_client.R
+++ b/R/read_lookup_sc_client.R
@@ -42,7 +42,7 @@ read_lookup_sc_client <- function(fyyear,
       "alcohol",
       "palliative_care",
       "carer",
-      "elderly_frail",
+      "elder_frail",
       "neurological_condition",
       "autism",
       "other_vulnerable_groups",
@@ -67,7 +67,7 @@ read_lookup_sc_client <- function(fyyear,
           "alcohol",
           "palliative_care",
           "carer",
-          "elderly_frail",
+          "elder_frail",
           "neurological_condition",
           "autism",
           "other_vulnerable_groups",
@@ -87,8 +87,10 @@ read_lookup_sc_client <- function(fyyear,
       .data$financial_year,
       .data$financial_quarter
     ) %>%
-    dplyr::rename("mental_health_disorders" = "mental_health_problems") %>%
-    dplyr::collect()
+    dplyr::rename(
+      "mental_health_disorders" = "mental_health_problems",
+      "elderly_frail" = "elder_frail"
+    )
 
   latest_quarter <- client_data %>%
     dplyr::arrange(dplyr::desc(.data$financial_quarter)) %>%

--- a/R/read_lookup_sc_client.R
+++ b/R/read_lookup_sc_client.R
@@ -53,8 +53,6 @@ read_lookup_sc_client <- function(fyyear,
       "meals",
       "day_care"
     ) %>%
-    dplyr::filter(.data$financial_year == year) %>%
-    dplyr::collect() %>%
     dplyr::mutate(
       dplyr::across(
         c(


### PR DESCRIPTION
This PR deals with a new change in how the client file is pulled in from the social care client platform. Previously, there was one client view containing both annual and quarterly data. A change request was pushed through which resulted in changes to how this was being extracted.

There are now two separate views, one for annual data and one for quarterly data which will be require to bind the two together. This update aligns us with what the SC team methods on extracting data from the client platform.