### PR TITLE
Denodo disconnect

### DIFF
--- a/SDL_process/run_sdl.r
+++ b/SDL_process/run_sdl.r
@@ -142,7 +142,6 @@ query_result <- dbGetQuery(denodo_connection, test_query)
 logger::log_info("Print test query result:")
 print(query_result)
 
-
 # close connection
 logger::log_info("Closing Denodo connection")
 DBI::dbDisconnect(denodo_connection)


### PR DESCRIPTION
Line of code added to disconnect from denodo using DBI's dbDisconnect function. It makes sure the Connect -> Query -> Disconnect workflow is complete thereby closing the ODBC connection.